### PR TITLE
fix(content_management): update sort order to descending for reposito…

### DIFF
--- a/lib/content_management/bloc/create_headline/create_headline_bloc.dart
+++ b/lib/content_management/bloc/create_headline/create_headline_bloc.dart
@@ -52,13 +52,13 @@ class CreateHeadlineBloc
         countriesResponse,
       ] = await Future.wait([
         _sourcesRepository.readAll(
-          sort: [const SortOption('updatedAt', SortOrder.asc)],
+          sort: [const SortOption('updatedAt', SortOrder.desc)],
         ),
         _topicsRepository.readAll(
-          sort: [const SortOption('updatedAt', SortOrder.asc)],
+          sort: [const SortOption('updatedAt', SortOrder.desc)],
         ),
         _countriesRepository.readAll(
-          sort: [const SortOption('updatedAt', SortOrder.asc)],
+          sort: [const SortOption('updatedAt', SortOrder.desc)],
         ),
       ]);
 

--- a/lib/content_management/bloc/create_source/create_source_bloc.dart
+++ b/lib/content_management/bloc/create_source/create_source_bloc.dart
@@ -39,7 +39,7 @@ class CreateSourceBloc extends Bloc<CreateSourceEvent, CreateSourceState> {
     emit(state.copyWith(status: CreateSourceStatus.loading));
     try {
       final countriesResponse = await _countriesRepository.readAll(
-        sort: [const SortOption('updatedAt', SortOrder.asc)],
+        sort: [const SortOption('updatedAt', SortOrder.desc)],
       );
       final countries = countriesResponse.items;
 

--- a/lib/content_management/bloc/edit_headline/edit_headline_bloc.dart
+++ b/lib/content_management/bloc/edit_headline/edit_headline_bloc.dart
@@ -54,13 +54,13 @@ class EditHeadlineBloc extends Bloc<EditHeadlineEvent, EditHeadlineState> {
       ] = await Future.wait([
         _headlinesRepository.read(id: _headlineId),
         _sourcesRepository.readAll(
-          sort: [const SortOption('updatedAt', SortOrder.asc)],
+          sort: [const SortOption('updatedAt', SortOrder.desc)],
         ),
         _topicsRepository.readAll(
-          sort: [const SortOption('updatedAt', SortOrder.asc)],
+          sort: [const SortOption('updatedAt', SortOrder.desc)],
         ),
         _countriesRepository.readAll(
-          sort: [const SortOption('updatedAt', SortOrder.asc)],
+          sort: [const SortOption('updatedAt', SortOrder.desc)],
         ),
       ]);
 

--- a/lib/content_management/bloc/edit_source/edit_source_bloc.dart
+++ b/lib/content_management/bloc/edit_source/edit_source_bloc.dart
@@ -43,7 +43,7 @@ class EditSourceBloc extends Bloc<EditSourceEvent, EditSourceState> {
       final [sourceResponse, countriesResponse] = await Future.wait([
         _sourcesRepository.read(id: _sourceId),
         _countriesRepository.readAll(
-          sort: [const SortOption('updatedAt', SortOrder.asc)],
+          sort: [const SortOption('updatedAt', SortOrder.desc)],
         ),
       ]);
       final source = sourceResponse as Source;


### PR DESCRIPTION
…ry reads

- Change sort order from ascending to descending for readAll operations in multiple repositories
- Update affected BLoCs: CreateHeadline, CreateSource, EditHeadline, EditSource
- Modify sort parameter in readAll methods for sources, topics, and countries repositories

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
