### PR TITLE
Sync app settings ads section with the core ads config

### DIFF
--- a/lib/app_configuration/widgets/ad_platform_config_form.dart
+++ b/lib/app_configuration/widgets/ad_platform_config_form.dart
@@ -245,10 +245,16 @@ class _AdPlatformConfigFormState extends State<AdPlatformConfigForm> {
                   ),
                 ),
                 segments: AdPlatformType.values
+                    .where(
+                      (type) =>
+                          type !=
+                          AdPlatformType
+                              .demo, // Ignore demo ad platform for dashboard
+                    )
                     .map(
-                      (platform) => ButtonSegment<AdPlatformType>(
-                        value: platform,
-                        label: Text(platform.l10n(context)),
+                      (type) => ButtonSegment<AdPlatformType>(
+                        value: type,
+                        label: Text(type.l10n(context)),
                       ),
                     )
                     .toList(),

--- a/lib/app_configuration/widgets/article_ad_settings_form.dart
+++ b/lib/app_configuration/widgets/article_ad_settings_form.dart
@@ -1,7 +1,7 @@
 import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
-import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/ad_type_l10n.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/banner_ad_shape_l10n.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/in_article_ad_slot_type_l10n.dart';
 import 'package:ui_kit/ui_kit.dart';
 
@@ -64,51 +64,47 @@ class _ArticleAdSettingsFormState extends State<ArticleAdSettingsForm>
         ),
         const SizedBox(height: AppSpacing.lg),
         ExpansionTile(
-          title: Text(l10n.defaultInArticleAdTypeSelectionTitle),
+          title: Text(l10n.bannerAdShapeSelectionTitle),
           childrenPadding: const EdgeInsetsDirectional.only(
-            start: AppSpacing.lg, // Adjusted padding for hierarchy
+            start: AppSpacing.lg,
             top: AppSpacing.md,
             bottom: AppSpacing.md,
           ),
-          expandedCrossAxisAlignment:
-              CrossAxisAlignment.start, // Align content to start
+          expandedCrossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l10n.defaultInArticleAdTypeSelectionDescription,
+              l10n.bannerAdShapeSelectionDescription,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Theme.of(
                   context,
                 ).colorScheme.onSurface.withOpacity(0.7),
               ),
-              textAlign: TextAlign.start, // Ensure text aligns to start
+              textAlign: TextAlign.start,
             ),
             const SizedBox(height: AppSpacing.lg),
             Align(
               alignment: AlignmentDirectional.centerStart,
-              child: SegmentedButton<AdType>(
+              child: SegmentedButton<BannerAdShape>(
                 style: SegmentedButton.styleFrom(
                   shape: const RoundedRectangleBorder(
                     borderRadius: BorderRadius.zero,
                   ),
                 ),
-                segments: AdType.values
-                    .where(
-                      (type) => type == AdType.native || type == AdType.banner,
-                    )
+                segments: BannerAdShape.values
                     .map(
-                      (type) => ButtonSegment<AdType>(
+                      (type) => ButtonSegment<BannerAdShape>(
                         value: type,
                         label: Text(type.l10n(context)),
                       ),
                     )
                     .toList(),
-                selected: {articleAdConfig.defaultInArticleAdType},
+                selected: {articleAdConfig.bannerAdShape},
                 onSelectionChanged: (newSelection) {
                   widget.onConfigChanged(
                     widget.remoteConfig.copyWith(
                       adConfig: adConfig.copyWith(
                         articleAdConfiguration: articleAdConfig.copyWith(
-                          defaultInArticleAdType: newSelection.first,
+                          bannerAdShape: newSelection.first,
                         ),
                       ),
                     ),
@@ -122,12 +118,11 @@ class _ArticleAdSettingsFormState extends State<ArticleAdSettingsForm>
         ExpansionTile(
           title: Text(l10n.inArticleAdSlotPlacementsTitle),
           childrenPadding: const EdgeInsetsDirectional.only(
-            start: AppSpacing.lg, // Adjusted padding for hierarchy
+            start: AppSpacing.lg,
             top: AppSpacing.md,
             bottom: AppSpacing.md,
           ),
-          expandedCrossAxisAlignment:
-              CrossAxisAlignment.start, // Align content to start
+          expandedCrossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               l10n.inArticleAdSlotPlacementsDescription,
@@ -136,7 +131,7 @@ class _ArticleAdSettingsFormState extends State<ArticleAdSettingsForm>
                   context,
                 ).colorScheme.onSurface.withOpacity(0.7),
               ),
-              textAlign: TextAlign.start, // Ensure text aligns to start
+              textAlign: TextAlign.start,
             ),
             const SizedBox(height: AppSpacing.lg),
             ...articleAdConfig.inArticleAdSlotConfigurations.map(

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2084,12 +2084,6 @@ abstract class AppLocalizations {
   /// **'The unit ID for banner ads within articles.'**
   String get inArticleBannerAdIdDescription;
 
-  /// Localized name for InArticleAdSlotType.belowMainArticleImage
-  ///
-  /// In en, this message translates to:
-  /// **'Below the main image of the article'**
-  String get inArticleAdSlotTypeBelowMainArticleImage;
-
   /// Localized name for InArticleAdSlotType.aboveArticleContinueReadingButton
   ///
   /// In en, this message translates to:
@@ -2407,6 +2401,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Video'**
   String get videoAdType;
+
+  /// Title for the Banner Ad Shape Selection section
+  ///
+  /// In en, this message translates to:
+  /// **'Banner Ad Shape'**
+  String get bannerAdShapeSelectionTitle;
+
+  /// Description for the Banner Ad Shape Selection section
+  ///
+  /// In en, this message translates to:
+  /// **'Select the preferred visual shape for banner ads displayed in articles.'**
+  String get bannerAdShapeSelectionDescription;
+
+  /// Label for the Square banner ad shape option
+  ///
+  /// In en, this message translates to:
+  /// **'Square'**
+  String get bannerAdShapeSquare;
+
+  /// Label for the Rectangle banner ad shape option
+  ///
+  /// In en, this message translates to:
+  /// **'Rectangle'**
+  String get bannerAdShapeRectangle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1109,10 +1109,6 @@ class AppLocalizationsAr extends AppLocalizations {
       'معرف وحدة إعلانات البانر داخل المقالات.';
 
   @override
-  String get inArticleAdSlotTypeBelowMainArticleImage =>
-      'أسفل الصورة الرئيسية للمقال';
-
-  @override
   String get inArticleAdSlotTypeAboveArticleContinueReadingButton =>
       'فوق زر \'متابعة القراءة\'';
 
@@ -1287,4 +1283,17 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get videoAdType => 'فيديو';
+
+  @override
+  String get bannerAdShapeSelectionTitle => 'شكل إعلان البانر';
+
+  @override
+  String get bannerAdShapeSelectionDescription =>
+      'اختر الشكل المرئي المفضل لإعلانات البانر المعروضة في المقالات.';
+
+  @override
+  String get bannerAdShapeSquare => 'مربع';
+
+  @override
+  String get bannerAdShapeRectangle => 'مستطيل';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1108,10 +1108,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'The unit ID for banner ads within articles.';
 
   @override
-  String get inArticleAdSlotTypeBelowMainArticleImage =>
-      'Below the main image of the article';
-
-  @override
   String get inArticleAdSlotTypeAboveArticleContinueReadingButton =>
       'Above the \'Continue Reading\' button';
 
@@ -1289,4 +1285,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get videoAdType => 'Video';
+
+  @override
+  String get bannerAdShapeSelectionTitle => 'Banner Ad Shape';
+
+  @override
+  String get bannerAdShapeSelectionDescription =>
+      'Select the preferred visual shape for banner ads displayed in articles.';
+
+  @override
+  String get bannerAdShapeSquare => 'Square';
+
+  @override
+  String get bannerAdShapeRectangle => 'Rectangle';
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1386,10 +1386,6 @@
   "@inArticleBannerAdIdDescription": {
     "description": "وصف حقل إدخال معرف إعلان البانر داخل المقال"
   },
-  "inArticleAdSlotTypeBelowMainArticleImage": "أسفل الصورة الرئيسية للمقال",
-  "@inArticleAdSlotTypeBelowMainArticleImage": {
-    "description": "الاسم المترجم لـ InArticleAdSlotType.belowMainArticleImage"
-  },
   "inArticleAdSlotTypeAboveArticleContinueReadingButton": "فوق زر 'متابعة القراءة'",
   "@inArticleAdSlotTypeAboveArticleContinueReadingButton": {
     "description": "الاسم المترجم لـ InArticleAdSlotType.aboveArticleContinueReadingButton"
@@ -1613,5 +1609,21 @@
   "videoAdType": "فيديو",
   "@videoAdType": {
     "description": "تسمية نوع إعلان الفيديو."
+  },
+  "bannerAdShapeSelectionTitle": "شكل إعلان البانر",
+  "@bannerAdShapeSelectionTitle": {
+    "description": "Title for the Banner Ad Shape Selection section"
+  },
+  "bannerAdShapeSelectionDescription": "اختر الشكل المرئي المفضل لإعلانات البانر المعروضة في المقالات.",
+  "@bannerAdShapeSelectionDescription": {
+    "description": "Description for the Banner Ad Shape Selection section"
+  },
+  "bannerAdShapeSquare": "مربع",
+  "@bannerAdShapeSquare": {
+    "description": "Label for the Square banner ad shape option"
+  },
+  "bannerAdShapeRectangle": "مستطيل",
+  "@bannerAdShapeRectangle": {
+    "description": "Label for the Rectangle banner ad shape option"
   }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1382,10 +1382,6 @@
   "@inArticleBannerAdIdDescription": {
     "description": "Description for the In-Article Banner Ad ID input field"
   },
-  "inArticleAdSlotTypeBelowMainArticleImage": "Below the main image of the article",
-  "@inArticleAdSlotTypeBelowMainArticleImage": {
-    "description": "Localized name for InArticleAdSlotType.belowMainArticleImage"
-  },
   "inArticleAdSlotTypeAboveArticleContinueReadingButton": "Above the 'Continue Reading' button",
   "@inArticleAdSlotTypeAboveArticleContinueReadingButton": {
     "description": "Localized name for InArticleAdSlotType.aboveArticleContinueReadingButton"
@@ -1609,5 +1605,21 @@
   "videoAdType": "Video",
   "@videoAdType": {
     "description": "Label for Video Ad Type."
+  },
+  "bannerAdShapeSelectionTitle": "Banner Ad Shape",
+  "@bannerAdShapeSelectionTitle": {
+    "description": "Title for the Banner Ad Shape Selection section"
+  },
+  "bannerAdShapeSelectionDescription": "Select the preferred visual shape for banner ads displayed in articles.",
+  "@bannerAdShapeSelectionDescription": {
+    "description": "Description for the Banner Ad Shape Selection section"
+  },
+  "bannerAdShapeSquare": "Square",
+  "@bannerAdShapeSquare": {
+    "description": "Label for the Square banner ad shape option"
+  },
+  "bannerAdShapeRectangle": "Rectangle",
+  "@bannerAdShapeRectangle": {
+    "description": "Label for the Rectangle banner ad shape option"
   }
 }

--- a/lib/shared/extensions/ad_platform_type_l10n.dart
+++ b/lib/shared/extensions/ad_platform_type_l10n.dart
@@ -12,6 +12,10 @@ extension AdPlatformTypeL10n on AdPlatformType {
         return l10n.adPlatformTypeAdmob;
       case AdPlatformType.local:
         return l10n.adPlatformTypeLocal;
+      case AdPlatformType.demo:
+        throw UnimplementedError(
+          'Demo ad platform type is not intended for dashboard usage, rather for mobile client, demo env specific usecase.',
+        );
     }
   }
 }

--- a/lib/shared/extensions/banner_ad_shape_l10n.dart
+++ b/lib/shared/extensions/banner_ad_shape_l10n.dart
@@ -1,0 +1,19 @@
+import 'package:core/core.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
+
+/// {@template banner_ad_shape_l10n}
+/// Extension on [BannerAdShape] to provide localized string representations.
+/// {@endtemplate}
+extension BannerAdShapeL10n on BannerAdShape {
+  /// Returns the localized name for a [BannerAdShape].
+  String l10n(BuildContext context) {
+    final l10n = context.l10n;
+    switch (this) {
+      case BannerAdShape.square:
+        return l10n.bannerAdShapeSquare;
+      case BannerAdShape.rectangle:
+        return l10n.bannerAdShapeRectangle;
+    }
+  }
+}

--- a/lib/shared/extensions/in_article_ad_slot_type_l10n.dart
+++ b/lib/shared/extensions/in_article_ad_slot_type_l10n.dart
@@ -10,8 +10,6 @@ extension InArticleAdSlotTypeL10n on InArticleAdSlotType {
   String l10n(BuildContext context) {
     final l10n = context.l10n;
     switch (this) {
-      case InArticleAdSlotType.belowMainArticleImage:
-        return l10n.inArticleAdSlotTypeBelowMainArticleImage;
       case InArticleAdSlotType.aboveArticleContinueReadingButton:
         return l10n.inArticleAdSlotTypeAboveArticleContinueReadingButton;
       case InArticleAdSlotType.belowArticleContinueReadingButton:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,7 +90,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "36be72f1b7bd22236eb0cdf97e5f2545c7a47d34"
+      resolved-ref: "8995bd33bcd3888675a6b18e11f3e8dc873261be"
       url: "https://github.com/flutter-news-app-full-source-code/core.git"
     source: git
     version: "0.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,7 +90,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "8995bd33bcd3888675a6b18e11f3e8dc873261be"
+      resolved-ref: dd37d11352124113978ebeda3b509d932db61cf5
       url: "https://github.com/flutter-news-app-full-source-code/core.git"
     source: git
     version: "0.0.0"


### PR DESCRIPTION
## Status

**READY**

## Description

This pull request focuses on synchronizing the application's ad settings within the dashboard with the core ad configuration. The primary goal is to refine the user interface for ad management, specifically by introducing more precise control over banner ad shapes and streamlining the display of ad platform types. These changes enhance the accuracy and usability of the ad configuration section.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
