### PR TITLE
Implementing a robust drafting feature for headline content management

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Click on any category to explore.
 
 ### 📰 Comprehensive Content Management
 Manage the entire lifecycle of your news content with full CRUD (Create, Read, Update, Delete) capabilities, complemented by advanced archiving and restoration features:
-- **Headlines:** Create, edit, publish, archive, restore, and permanently delete news articles.
-- **Topics:** Organize, define, archive, and restore news topics.
-- **Sources:** Maintain, update, archive, and restore news sources.
-> **💡 Your Advantage:** Gain detailed control over your content. This centralized system ensures accuracy and consistency, allowing you to manage active content and easily retrieve or remove archived items.
+- **Headlines:** Draft, Create, edit, publish, archive, restore, and permanently delete news articles.
+- **Topics:** Draft, Create, edit, archive, and restore news topics.
+- **Sources:** Draft, Create, edit, archive, and restore news sources.
+> **💡 Your Advantage:** Gain detailed control over your content. This centralized system ensures accuracy and consistency, allowing you to manage draft/active content and easily retrieve or remove archived items.
 
 ---
 

--- a/lib/bloc_observer.dart
+++ b/lib/bloc_observer.dart
@@ -15,38 +15,15 @@ class AppBlocObserver extends BlocObserver {
 
     // Initialize state information strings.
     // By default, truncate the full string representation of the state
-    // to the first 250 characters to prevent excessively long logs.
-    var oldStateInfo = oldState.toString().substring(
+    // to the first 150 characters to prevent excessively long logs.
+    final oldStateInfo = oldState.toString().substring(
       0,
-      oldState.toString().length > 250 ? 250 : oldState.toString().length,
+      oldState.toString().length > 150 ? 150 : oldState.toString().length,
     );
-    var newStateInfo = newState.toString().substring(
+    final newStateInfo = newState.toString().substring(
       0,
-      newState.toString().length > 250 ? 250 : newState.toString().length,
+      newState.toString().length > 150 ? 150 : newState.toString().length,
     );
-
-    try {
-      // Attempt to access a 'status' property on the state objects.
-      // Many BLoC states use a 'status' property (e.g., Loading, Success, Failure)
-      // to represent their current lifecycle phase. If this property exists
-      // and is not null, prioritize logging its value for conciseness.
-      if (oldState.status != null) {
-        oldStateInfo = 'status: ${oldState.status}';
-      }
-      if (newState.status != null) {
-        newStateInfo = 'status: ${newState.status}';
-      }
-    } catch (e) {
-      // This catch block handles cases where:
-      // 1. The 'status' property does not exist on the state object (NoSuchMethodError).
-      // 2. Accessing 'status' throws any other runtime error.
-      // In such scenarios, the `oldStateInfo` and `newStateInfo` variables
-      // will retain their initially truncated string representations,
-      // providing a fallback for states without a 'status' property.
-      // Log the error for debugging purposes, but do not rethrow to avoid
-      // crashing the observer.
-      log('Error accessing status property for ${bloc.runtimeType}: $e');
-    }
 
     // Log the state change, including the BLoC type and the old and new state information.
     log('onChange(${bloc.runtimeType}, $oldStateInfo -> $newStateInfo)');

--- a/lib/content_management/bloc/create_headline/create_headline_bloc.dart
+++ b/lib/content_management/bloc/create_headline/create_headline_bloc.dart
@@ -85,18 +85,6 @@ class CreateHeadlineBloc
     CreateHeadlineSavedAsDraft event,
     Emitter<CreateHeadlineState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: CreateHeadlineStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: CreateHeadlineStatus.submitting));
     try {
       final now = DateTime.now();
@@ -138,18 +126,6 @@ class CreateHeadlineBloc
     CreateHeadlinePublished event,
     Emitter<CreateHeadlineState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: CreateHeadlineStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: CreateHeadlineStatus.submitting));
     try {
       final now = DateTime.now();

--- a/lib/content_management/bloc/create_headline/create_headline_event.dart
+++ b/lib/content_management/bloc/create_headline/create_headline_event.dart
@@ -64,21 +64,6 @@ final class CreateHeadlineCountryChanged extends CreateHeadlineEvent {
   List<Object?> get props => [country];
 }
 
-/// Event for when the headline's status is changed.
-final class CreateHeadlineStatusChanged extends CreateHeadlineEvent {
-  const CreateHeadlineStatusChanged(this.status);
-
-  final ContentStatus status;
-
-  @override
-  List<Object?> get props => [status];
-}
-
-/// Event to signal that the form should be submitted.
-final class CreateHeadlineSubmitted extends CreateHeadlineEvent {
-  const CreateHeadlineSubmitted();
-}
-
 /// Event to save the headline as a draft.
 final class CreateHeadlineSavedAsDraft extends CreateHeadlineEvent {
   const CreateHeadlineSavedAsDraft();

--- a/lib/content_management/bloc/create_headline/create_headline_state.dart
+++ b/lib/content_management/bloc/create_headline/create_headline_state.dart
@@ -29,7 +29,6 @@ final class CreateHeadlineState extends Equatable {
     this.source,
     this.topic,
     this.eventCountry,
-    this.contentStatus = ContentStatus.active,
     this.exception,
     this.createdHeadline,
   });
@@ -42,7 +41,6 @@ final class CreateHeadlineState extends Equatable {
   final Source? source;
   final Topic? topic;
   final Country? eventCountry;
-  final ContentStatus contentStatus;
   final HttpException? exception;
   final Headline? createdHeadline;
 
@@ -65,7 +63,6 @@ final class CreateHeadlineState extends Equatable {
     ValueGetter<Source?>? source,
     ValueGetter<Topic?>? topic,
     ValueGetter<Country?>? eventCountry,
-    ContentStatus? contentStatus,
     HttpException? exception,
     Headline? createdHeadline,
   }) {
@@ -78,7 +75,6 @@ final class CreateHeadlineState extends Equatable {
       source: source != null ? source() : this.source,
       topic: topic != null ? topic() : this.topic,
       eventCountry: eventCountry != null ? eventCountry() : this.eventCountry,
-      contentStatus: contentStatus ?? this.contentStatus,
       exception: exception,
       createdHeadline: createdHeadline ?? this.createdHeadline,
     );
@@ -94,7 +90,6 @@ final class CreateHeadlineState extends Equatable {
     source,
     topic,
     eventCountry,
-    contentStatus,
     exception,
     createdHeadline,
   ];

--- a/lib/content_management/bloc/create_source/create_source_bloc.dart
+++ b/lib/content_management/bloc/create_source/create_source_bloc.dart
@@ -75,18 +75,6 @@ class CreateSourceBloc extends Bloc<CreateSourceEvent, CreateSourceState> {
     CreateSourceSavedAsDraft event,
     Emitter<CreateSourceState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: CreateSourceStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: CreateSourceStatus.submitting));
     try {
       final now = DateTime.now();
@@ -127,18 +115,6 @@ class CreateSourceBloc extends Bloc<CreateSourceEvent, CreateSourceState> {
     CreateSourcePublished event,
     Emitter<CreateSourceState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: CreateSourceStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: CreateSourceStatus.submitting));
     try {
       final now = DateTime.now();

--- a/lib/content_management/bloc/create_source/create_source_event.dart
+++ b/lib/content_management/bloc/create_source/create_source_event.dart
@@ -56,17 +56,12 @@ final class CreateSourceHeadquartersChanged extends CreateSourceEvent {
   List<Object?> get props => [headquarters];
 }
 
-/// Event for when the source's status is changed.
-final class CreateSourceStatusChanged extends CreateSourceEvent {
-  const CreateSourceStatusChanged(this.status);
-
-  final ContentStatus status;
-
-  @override
-  List<Object?> get props => [status];
+/// Event to save the source as a draft.
+final class CreateSourceSavedAsDraft extends CreateSourceEvent {
+  const CreateSourceSavedAsDraft();
 }
 
-/// Event to signal that the form should be submitted.
-final class CreateSourceSubmitted extends CreateSourceEvent {
-  const CreateSourceSubmitted();
+/// Event to publish the source.
+final class CreateSourcePublished extends CreateSourceEvent {
+  const CreateSourcePublished();
 }

--- a/lib/content_management/bloc/create_source/create_source_state.dart
+++ b/lib/content_management/bloc/create_source/create_source_state.dart
@@ -29,7 +29,6 @@ final class CreateSourceState extends Equatable {
     this.sourceType,
     this.language,
     this.headquarters,
-    this.contentStatus = ContentStatus.active,
     this.exception,
     this.createdSource,
   });
@@ -41,7 +40,6 @@ final class CreateSourceState extends Equatable {
   final SourceType? sourceType;
   final Language? language;
   final Country? headquarters;
-  final ContentStatus contentStatus;
   final HttpException? exception;
   final Source? createdSource;
 
@@ -62,7 +60,6 @@ final class CreateSourceState extends Equatable {
     ValueGetter<SourceType?>? sourceType,
     ValueGetter<Language?>? language,
     ValueGetter<Country?>? headquarters,
-    ContentStatus? contentStatus,
     HttpException? exception,
     Source? createdSource,
   }) {
@@ -74,7 +71,6 @@ final class CreateSourceState extends Equatable {
       sourceType: sourceType != null ? sourceType() : this.sourceType,
       language: language != null ? language() : this.language,
       headquarters: headquarters != null ? headquarters() : this.headquarters,
-      contentStatus: contentStatus ?? this.contentStatus,
       exception: exception,
       createdSource: createdSource ?? this.createdSource,
     );
@@ -89,7 +85,6 @@ final class CreateSourceState extends Equatable {
     sourceType,
     language,
     headquarters,
-    contentStatus,
     exception,
     createdSource,
   ];

--- a/lib/content_management/bloc/create_topic/create_topic_bloc.dart
+++ b/lib/content_management/bloc/create_topic/create_topic_bloc.dart
@@ -16,8 +16,8 @@ class CreateTopicBloc extends Bloc<CreateTopicEvent, CreateTopicState> {
     on<CreateTopicNameChanged>(_onNameChanged);
     on<CreateTopicDescriptionChanged>(_onDescriptionChanged);
     on<CreateTopicIconUrlChanged>(_onIconUrlChanged);
-    on<CreateTopicStatusChanged>(_onStatusChanged);
-    on<CreateTopicSubmitted>(_onSubmitted);
+    on<CreateTopicSavedAsDraft>(_onSavedAsDraft);
+    on<CreateTopicPublished>(_onPublished);
   }
 
   final DataRepository<Topic> _topicsRepository;
@@ -51,23 +51,22 @@ class CreateTopicBloc extends Bloc<CreateTopicEvent, CreateTopicState> {
     );
   }
 
-  void _onStatusChanged(
-    CreateTopicStatusChanged event,
-    Emitter<CreateTopicState> emit,
-  ) {
-    emit(
-      state.copyWith(
-        contentStatus: event.status,
-        status: CreateTopicStatus.initial,
-      ),
-    );
-  }
-
-  Future<void> _onSubmitted(
-    CreateTopicSubmitted event,
+  /// Handles saving the topic as a draft.
+  Future<void> _onSavedAsDraft(
+    CreateTopicSavedAsDraft event,
     Emitter<CreateTopicState> emit,
   ) async {
-    if (!state.isFormValid) return;
+    if (!state.isFormValid) {
+      emit(
+        state.copyWith(
+          status: CreateTopicStatus.failure,
+          exception: const InvalidInputException(
+            'Form is not valid. Please complete all required fields.',
+          ),
+        ),
+      );
+      return;
+    }
 
     emit(state.copyWith(status: CreateTopicStatus.submitting));
     try {
@@ -77,7 +76,56 @@ class CreateTopicBloc extends Bloc<CreateTopicEvent, CreateTopicState> {
         name: state.name,
         description: state.description,
         iconUrl: state.iconUrl,
-        status: state.contentStatus,
+        status: ContentStatus.draft,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      await _topicsRepository.create(item: newTopic);
+      emit(
+        state.copyWith(
+          status: CreateTopicStatus.success,
+          createdTopic: newTopic,
+        ),
+      );
+    } on HttpException catch (e) {
+      emit(state.copyWith(status: CreateTopicStatus.failure, exception: e));
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: CreateTopicStatus.failure,
+          exception: UnknownException('An unexpected error occurred: $e'),
+        ),
+      );
+    }
+  }
+
+  /// Handles publishing the topic.
+  Future<void> _onPublished(
+    CreateTopicPublished event,
+    Emitter<CreateTopicState> emit,
+  ) async {
+    if (!state.isFormValid) {
+      emit(
+        state.copyWith(
+          status: CreateTopicStatus.failure,
+          exception: const InvalidInputException(
+            'Form is not valid. Please complete all required fields.',
+          ),
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: CreateTopicStatus.submitting));
+    try {
+      final now = DateTime.now();
+      final newTopic = Topic(
+        id: _uuid.v4(),
+        name: state.name,
+        description: state.description,
+        iconUrl: state.iconUrl,
+        status: ContentStatus.active,
         createdAt: now,
         updatedAt: now,
       );

--- a/lib/content_management/bloc/create_topic/create_topic_bloc.dart
+++ b/lib/content_management/bloc/create_topic/create_topic_bloc.dart
@@ -56,18 +56,6 @@ class CreateTopicBloc extends Bloc<CreateTopicEvent, CreateTopicState> {
     CreateTopicSavedAsDraft event,
     Emitter<CreateTopicState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: CreateTopicStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: CreateTopicStatus.submitting));
     try {
       final now = DateTime.now();
@@ -105,18 +93,6 @@ class CreateTopicBloc extends Bloc<CreateTopicEvent, CreateTopicState> {
     CreateTopicPublished event,
     Emitter<CreateTopicState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: CreateTopicStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: CreateTopicStatus.submitting));
     try {
       final now = DateTime.now();

--- a/lib/content_management/bloc/create_topic/create_topic_event.dart
+++ b/lib/content_management/bloc/create_topic/create_topic_event.dart
@@ -32,16 +32,12 @@ final class CreateTopicIconUrlChanged extends CreateTopicEvent {
   List<Object?> get props => [iconUrl];
 }
 
-/// Event for when the topic's status is changed.
-final class CreateTopicStatusChanged extends CreateTopicEvent {
-  const CreateTopicStatusChanged(this.status);
-
-  final ContentStatus status;
-  @override
-  List<Object?> get props => [status];
+/// Event to save the topic as a draft.
+final class CreateTopicSavedAsDraft extends CreateTopicEvent {
+  const CreateTopicSavedAsDraft();
 }
 
-/// Event to signal that the form should be submitted.
-final class CreateTopicSubmitted extends CreateTopicEvent {
-  const CreateTopicSubmitted();
+/// Event to publish the topic.
+final class CreateTopicPublished extends CreateTopicEvent {
+  const CreateTopicPublished();
 }

--- a/lib/content_management/bloc/create_topic/create_topic_state.dart
+++ b/lib/content_management/bloc/create_topic/create_topic_state.dart
@@ -23,7 +23,6 @@ final class CreateTopicState extends Equatable {
     this.name = '',
     this.description = '',
     this.iconUrl = '',
-    this.contentStatus = ContentStatus.active,
     this.exception,
     this.createdTopic,
   });
@@ -32,7 +31,6 @@ final class CreateTopicState extends Equatable {
   final String name;
   final String description;
   final String iconUrl;
-  final ContentStatus contentStatus;
   final HttpException? exception;
   final Topic? createdTopic;
 
@@ -46,7 +44,6 @@ final class CreateTopicState extends Equatable {
     String? name,
     String? description,
     String? iconUrl,
-    ContentStatus? contentStatus,
     HttpException? exception,
     Topic? createdTopic,
   }) {
@@ -55,7 +52,6 @@ final class CreateTopicState extends Equatable {
       name: name ?? this.name,
       description: description ?? this.description,
       iconUrl: iconUrl ?? this.iconUrl,
-      contentStatus: contentStatus ?? this.contentStatus,
       exception: exception,
       createdTopic: createdTopic ?? this.createdTopic,
     );
@@ -67,7 +63,6 @@ final class CreateTopicState extends Equatable {
     name,
     description,
     iconUrl,
-    contentStatus,
     exception,
     createdTopic,
   ];

--- a/lib/content_management/bloc/draft_headlines/draft_headlines_bloc.dart
+++ b/lib/content_management/bloc/draft_headlines/draft_headlines_bloc.dart
@@ -114,13 +114,13 @@ class DraftHeadlinesBloc
     PublishDraftHeadlineRequested event,
     Emitter<DraftHeadlinesState> emit,
   ) async {
-    final originalHeadlines = List<Headline>.from(state.headlines);
+    final originalHeadlines = state.headlines;
     final headlineIndex = originalHeadlines.indexWhere((h) => h.id == event.id);
     if (headlineIndex == -1) return;
-
     final headlineToPublish = originalHeadlines[headlineIndex];
-    final updatedHeadlines = originalHeadlines..removeAt(headlineIndex);
-
+    final updatedHeadlines = List<Headline>.from(originalHeadlines)
+      ..removeAt(headlineIndex);
+      
     // Optimistically remove the headline from the UI.
     emit(
       state.copyWith(

--- a/lib/content_management/bloc/draft_headlines/draft_headlines_state.dart
+++ b/lib/content_management/bloc/draft_headlines/draft_headlines_state.dart
@@ -82,8 +82,10 @@ class DraftHeadlinesState extends Equatable {
       // to ensure they are cleared after being handled.
       exception: exception,
       publishedHeadline: publishedHeadline,
-      lastPendingDeletionId: lastPendingDeletionId,
-      snackbarHeadlineTitle: snackbarHeadlineTitle,
+      lastPendingDeletionId:
+          lastPendingDeletionId ?? this.lastPendingDeletionId,
+      snackbarHeadlineTitle:
+          snackbarHeadlineTitle ?? this.snackbarHeadlineTitle,
     );
   }
 

--- a/lib/content_management/bloc/draft_sources/draft_sources_bloc.dart
+++ b/lib/content_management/bloc/draft_sources/draft_sources_bloc.dart
@@ -1,0 +1,261 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:core/core.dart';
+import 'package:data_repository/data_repository.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/shared/services/pending_deletions_service.dart';
+
+part 'draft_sources_event.dart';
+part 'draft_sources_state.dart';
+
+/// {@template draft_sources_bloc}
+/// A BLoC responsible for managing the state of draft sources.
+///
+/// It handles loading, publishing, and permanently deleting draft sources,
+/// including a temporary "undo" period for deletions.
+/// {@endtemplate}
+class DraftSourcesBloc extends Bloc<DraftSourcesEvent, DraftSourcesState> {
+  /// {@macro draft_sources_bloc}
+  DraftSourcesBloc({
+    required DataRepository<Source> sourcesRepository,
+    required PendingDeletionsService pendingDeletionsService,
+  }) : _sourcesRepository = sourcesRepository,
+       _pendingDeletionsService = pendingDeletionsService,
+       super(const DraftSourcesState()) {
+    on<LoadDraftSourcesRequested>(_onLoadDraftSourcesRequested);
+    on<PublishDraftSourceRequested>(_onPublishDraftSourceRequested);
+    on<_DeletionServiceStatusChanged>(
+      _onDeletionServiceStatusChanged,
+    );
+    on<DeleteDraftSourceForeverRequested>(
+      _onDeleteDraftSourceForeverRequested,
+    );
+    on<UndoDeleteDraftSourceRequested>(_onUndoDeleteDraftSourceRequested);
+    on<ClearPublishedSource>(_onClearPublishedSource);
+
+    // Listen to deletion events from the PendingDeletionsService.
+    // The filter now correctly checks the type of the item in the event.
+    _deletionEventSubscription = _pendingDeletionsService.deletionEvents.listen(
+      (event) {
+        if (event.item is Source) {
+          add(_DeletionServiceStatusChanged(event));
+        }
+      },
+    );
+  }
+
+  final DataRepository<Source> _sourcesRepository;
+  final PendingDeletionsService _pendingDeletionsService;
+
+  /// Subscription to deletion events from the PendingDeletionsService.
+  late final StreamSubscription<DeletionEvent<dynamic>>
+  _deletionEventSubscription;
+
+  @override
+  Future<void> close() async {
+    // Cancel the subscription to deletion events to prevent memory leaks.
+    await _deletionEventSubscription.cancel();
+    return super.close();
+  }
+
+  /// Handles the request to load draft sources.
+  ///
+  /// Fetches paginated draft sources from the repository and updates the state.
+  Future<void> _onLoadDraftSourcesRequested(
+    LoadDraftSourcesRequested event,
+    Emitter<DraftSourcesState> emit,
+  ) async {
+    emit(state.copyWith(status: DraftSourcesStatus.loading));
+    try {
+      final isPaginating = event.startAfterId != null;
+      final previousSources = isPaginating ? state.sources : <Source>[];
+
+      final paginatedSources = await _sourcesRepository.readAll(
+        filter: {'status': ContentStatus.draft.name},
+        sort: [const SortOption('updatedAt', SortOrder.desc)],
+        pagination: PaginationOptions(
+          cursor: event.startAfterId,
+          limit: event.limit,
+        ),
+      );
+      emit(
+        state.copyWith(
+          status: DraftSourcesStatus.success,
+          sources: [...previousSources, ...paginatedSources.items],
+          cursor: paginatedSources.cursor,
+          hasMore: paginatedSources.hasMore,
+        ),
+      );
+    } on HttpException catch (e) {
+      emit(
+        state.copyWith(
+          status: DraftSourcesStatus.failure,
+          exception: e,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: DraftSourcesStatus.failure,
+          exception: UnknownException('An unexpected error occurred: $e'),
+        ),
+      );
+    }
+  }
+
+  /// Handles the request to publish a draft source.
+  ///
+  /// Optimistically removes the source from the UI, updates its status to active
+  /// in the repository, and then updates the state. If the source was pending
+  /// deletion, its pending deletion is cancelled.
+  Future<void> _onPublishDraftSourceRequested(
+    PublishDraftSourceRequested event,
+    Emitter<DraftSourcesState> emit,
+  ) async {
+    final originalSources = List<Source>.from(state.sources);
+    final sourceIndex = originalSources.indexWhere((s) => s.id == event.id);
+    if (sourceIndex == -1) return;
+
+    final sourceToPublish = originalSources[sourceIndex];
+    final updatedSources = originalSources..removeAt(sourceIndex);
+
+    // Optimistically remove the source from the UI.
+    emit(
+      state.copyWith(
+        sources: updatedSources,
+        lastPendingDeletionId: state.lastPendingDeletionId == event.id
+            ? null
+            : state.lastPendingDeletionId,
+        snackbarSourceTitle: null,
+      ),
+    );
+
+    try {
+      final publishedSource = await _sourcesRepository.update(
+        id: event.id,
+        item: sourceToPublish.copyWith(status: ContentStatus.active),
+      );
+      emit(state.copyWith(publishedSource: publishedSource));
+    } on HttpException catch (e) {
+      // If the update fails, revert the change in the UI
+      emit(
+        state.copyWith(
+          sources: originalSources,
+          exception: e,
+          lastPendingDeletionId: state.lastPendingDeletionId,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          sources: originalSources,
+          exception: UnknownException('An unexpected error occurred: $e'),
+          lastPendingDeletionId: state.lastPendingDeletionId,
+        ),
+      );
+    }
+  }
+
+  /// Handles deletion events from the [PendingDeletionsService].
+  ///
+  /// This method is called when an item's deletion is confirmed or undone
+  /// by the service. It updates the BLoC's state accordingly.
+  Future<void> _onDeletionServiceStatusChanged(
+    _DeletionServiceStatusChanged event,
+    Emitter<DraftSourcesState> emit,
+  ) async {
+    final id = event.event.id;
+    final status = event.event.status;
+    final item = event.event.item;
+
+    if (status == DeletionStatus.confirmed) {
+      // Deletion confirmed, no action needed in BLoC as it was optimistically removed.
+      // Ensure lastPendingDeletionId and snackbarSourceTitle are cleared if this was the one.
+      emit(
+        state.copyWith(
+          lastPendingDeletionId: state.lastPendingDeletionId == id
+              ? null
+              : state.lastPendingDeletionId,
+          snackbarSourceTitle: null,
+        ),
+      );
+    } else if (status == DeletionStatus.undone) {
+      // Deletion undone, restore the source to the main list.
+      if (item is Source) {
+        final insertionIndex = state.sources.indexWhere(
+          (s) => s.updatedAt.isBefore(item.updatedAt),
+        );
+        final updatedSources = List<Source>.from(state.sources)
+          ..insert(
+            insertionIndex != -1 ? insertionIndex : state.sources.length,
+            item,
+          );
+        emit(
+          state.copyWith(
+            sources: updatedSources,
+            lastPendingDeletionId: state.lastPendingDeletionId == id
+                ? null
+                : state.lastPendingDeletionId,
+            snackbarSourceTitle: null,
+          ),
+        );
+      }
+    }
+  }
+
+  /// Handles the request to permanently delete a draft source.
+  ///
+  /// This optimistically removes the source from the UI and initiates a
+  /// timed deletion via the [PendingDeletionsService].
+  Future<void> _onDeleteDraftSourceForeverRequested(
+    DeleteDraftSourceForeverRequested event,
+    Emitter<DraftSourcesState> emit,
+  ) async {
+    final sourceToDelete = state.sources.firstWhere(
+      (s) => s.id == event.id,
+    );
+
+    // Optimistically remove the source from the UI.
+    final updatedSources = List<Source>.from(state.sources)
+      ..removeWhere((s) => s.id == event.id);
+
+    emit(
+      state.copyWith(
+        sources: updatedSources,
+        lastPendingDeletionId: event.id,
+        snackbarSourceTitle: sourceToDelete.name,
+      ),
+    );
+
+    // Request deletion via the service.
+    _pendingDeletionsService.requestDeletion(
+      item: sourceToDelete,
+      repository: _sourcesRepository,
+      undoDuration: const Duration(seconds: 5),
+    );
+  }
+
+  /// Handles the request to undo a pending deletion of a draft source.
+  ///
+  /// This cancels the deletion timer in the [PendingDeletionsService].
+  Future<void> _onUndoDeleteDraftSourceRequested(
+    UndoDeleteDraftSourceRequested event,
+    Emitter<DraftSourcesState> emit,
+  ) async {
+    _pendingDeletionsService.undoDeletion(event.id);
+    // The _onDeletionServiceStatusChanged will handle re-adding to the list
+    // and updating pendingDeletions when DeletionStatus.undone is emitted.
+  }
+
+  /// Handles the request to clear the published source from the state.
+  ///
+  /// This is typically called after the UI has processed the published source
+  /// and no longer needs it in the state.
+  void _onClearPublishedSource(
+    ClearPublishedSource event,
+    Emitter<DraftSourcesState> emit,
+  ) {
+    emit(state.copyWith(publishedSource: null, snackbarSourceTitle: null));
+  }
+}

--- a/lib/content_management/bloc/draft_sources/draft_sources_bloc.dart
+++ b/lib/content_management/bloc/draft_sources/draft_sources_bloc.dart
@@ -113,12 +113,12 @@ class DraftSourcesBloc extends Bloc<DraftSourcesEvent, DraftSourcesState> {
     PublishDraftSourceRequested event,
     Emitter<DraftSourcesState> emit,
   ) async {
-    final originalSources = List<Source>.from(state.sources);
+    final originalSources = state.sources;
     final sourceIndex = originalSources.indexWhere((s) => s.id == event.id);
     if (sourceIndex == -1) return;
-
     final sourceToPublish = originalSources[sourceIndex];
-    final updatedSources = originalSources..removeAt(sourceIndex);
+    final updatedSources = List<Source>.from(originalSources)
+      ..removeAt(sourceIndex);
 
     // Optimistically remove the source from the UI.
     emit(

--- a/lib/content_management/bloc/draft_sources/draft_sources_event.dart
+++ b/lib/content_management/bloc/draft_sources/draft_sources_event.dart
@@ -1,0 +1,72 @@
+part of 'draft_sources_bloc.dart';
+
+sealed class DraftSourcesEvent extends Equatable {
+  const DraftSourcesEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Event to request loading of draft sources.
+final class LoadDraftSourcesRequested extends DraftSourcesEvent {
+  const LoadDraftSourcesRequested({this.startAfterId, this.limit});
+
+  final String? startAfterId;
+  final int? limit;
+
+  @override
+  List<Object?> get props => [startAfterId, limit];
+}
+
+/// Event to publish a draft source.
+final class PublishDraftSourceRequested extends DraftSourcesEvent {
+  const PublishDraftSourceRequested(this.id);
+
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+}
+
+/// Event to request permanent deletion of a draft source.
+final class DeleteDraftSourceForeverRequested extends DraftSourcesEvent {
+  /// {@macro delete_draft_source_forever_requested}
+  const DeleteDraftSourceForeverRequested(this.id);
+
+  /// The ID of the source to permanently delete.
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+}
+
+/// Event to undo a pending deletion of a draft source.
+final class UndoDeleteDraftSourceRequested extends DraftSourcesEvent {
+  /// {@macro undo_delete_draft_source_requested}
+  const UndoDeleteDraftSourceRequested(this.id);
+
+  /// The ID of the source whose deletion should be undone.
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+}
+
+/// Event to clear the published source from the state.
+final class ClearPublishedSource extends DraftSourcesEvent {
+  /// {@macro clear_published_source}
+  const ClearPublishedSource();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Event to handle updates from the pending deletions service.
+final class _DeletionServiceStatusChanged extends DraftSourcesEvent {
+  const _DeletionServiceStatusChanged(this.event);
+
+  final DeletionEvent<dynamic> event;
+
+  @override
+  List<Object?> get props => [event];
+}

--- a/lib/content_management/bloc/draft_sources/draft_sources_state.dart
+++ b/lib/content_management/bloc/draft_sources/draft_sources_state.dart
@@ -82,8 +82,9 @@ class DraftSourcesState extends Equatable {
       // to ensure they are cleared after being handled.
       exception: exception,
       publishedSource: publishedSource,
-      lastPendingDeletionId: lastPendingDeletionId,
-      snackbarSourceTitle: snackbarSourceTitle,
+      lastPendingDeletionId:
+          lastPendingDeletionId ?? this.lastPendingDeletionId,
+      snackbarSourceTitle: snackbarSourceTitle ?? this.snackbarSourceTitle,
     );
   }
 

--- a/lib/content_management/bloc/draft_sources/draft_sources_state.dart
+++ b/lib/content_management/bloc/draft_sources/draft_sources_state.dart
@@ -1,0 +1,101 @@
+part of 'draft_sources_bloc.dart';
+
+/// Represents the status of draft content operations.
+enum DraftSourcesStatus {
+  /// The operation is in its initial state.
+  initial,
+
+  /// Data is currently being loaded or an operation is in progress.
+  loading,
+
+  /// Data has been successfully loaded or an operation completed.
+  success,
+
+  /// An error occurred during data loading or an operation.
+  failure,
+}
+
+/// {@template draft_sources_state}
+/// The state for the draft content feature.
+///
+/// Manages the list of draft sources, pagination details,
+/// and any pending deletion operations.
+/// {@endtemplate}
+class DraftSourcesState extends Equatable {
+  /// {@macro draft_sources_state}
+  const DraftSourcesState({
+    this.status = DraftSourcesStatus.initial,
+    this.sources = const [],
+    this.cursor,
+    this.hasMore = false,
+    this.exception,
+    this.publishedSource,
+    this.lastPendingDeletionId,
+    this.snackbarSourceTitle,
+  });
+
+  /// The current status of the draft sources operations.
+  final DraftSourcesStatus status;
+
+  /// The list of draft sources currently displayed.
+  final List<Source> sources;
+
+  /// The cursor for fetching the next page of draft sources.
+  /// A `null` value indicates no more pages.
+  final String? cursor;
+
+  /// Indicates if there are more draft sources available to load.
+  final bool hasMore;
+
+  /// The exception encountered during a failed operation, if any.
+  final HttpException? exception;
+
+  /// The source that was most recently published, if any.
+  final Source? publishedSource;
+
+  /// The ID of the source that was most recently added to pending deletions.
+  /// Used to trigger the snackbar display.
+  final String? lastPendingDeletionId;
+
+  /// The title of the source for which the snackbar should be displayed.
+  /// This is set when a deletion is requested and cleared when the snackbar
+  /// is no longer needed.
+  final String? snackbarSourceTitle;
+
+  /// Creates a copy of this [DraftSourcesState] with updated values.
+  DraftSourcesState copyWith({
+    DraftSourcesStatus? status,
+    List<Source>? sources,
+    String? cursor,
+    bool? hasMore,
+    HttpException? exception,
+    Source? publishedSource,
+    String? lastPendingDeletionId,
+    String? snackbarSourceTitle,
+  }) {
+    return DraftSourcesState(
+      status: status ?? this.status,
+      sources: sources ?? this.sources,
+      cursor: cursor ?? this.cursor,
+      hasMore: hasMore ?? this.hasMore,
+      // Exception and publishedSource are explicitly set to null if not provided
+      // to ensure they are cleared after being handled.
+      exception: exception,
+      publishedSource: publishedSource,
+      lastPendingDeletionId: lastPendingDeletionId,
+      snackbarSourceTitle: snackbarSourceTitle,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    status,
+    sources,
+    cursor,
+    hasMore,
+    exception,
+    publishedSource,
+    lastPendingDeletionId,
+    snackbarSourceTitle,
+  ];
+}

--- a/lib/content_management/bloc/draft_topics/draft_topics_bloc.dart
+++ b/lib/content_management/bloc/draft_topics/draft_topics_bloc.dart
@@ -113,13 +113,13 @@ class DraftTopicsBloc extends Bloc<DraftTopicsEvent, DraftTopicsState> {
     PublishDraftTopicRequested event,
     Emitter<DraftTopicsState> emit,
   ) async {
-    final originalTopics = List<Topic>.from(state.topics);
+    final originalTopics = state.topics;
     final topicIndex = originalTopics.indexWhere((t) => t.id == event.id);
     if (topicIndex == -1) return;
-
     final topicToPublish = originalTopics[topicIndex];
-    final updatedTopics = originalTopics..removeAt(topicIndex);
-
+    final updatedTopics = List<Topic>.from(originalTopics)
+      ..removeAt(topicIndex);
+      
     // Optimistically remove the topic from the UI.
     emit(
       state.copyWith(

--- a/lib/content_management/bloc/draft_topics/draft_topics_bloc.dart
+++ b/lib/content_management/bloc/draft_topics/draft_topics_bloc.dart
@@ -1,0 +1,261 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:core/core.dart';
+import 'package:data_repository/data_repository.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/shared/services/pending_deletions_service.dart';
+
+part 'draft_topics_event.dart';
+part 'draft_topics_state.dart';
+
+/// {@template draft_topics_bloc}
+/// A BLoC responsible for managing the state of draft topics.
+///
+/// It handles loading, publishing, and permanently deleting draft topics,
+/// including a temporary "undo" period for deletions.
+/// {@endtemplate}
+class DraftTopicsBloc extends Bloc<DraftTopicsEvent, DraftTopicsState> {
+  /// {@macro draft_topics_bloc}
+  DraftTopicsBloc({
+    required DataRepository<Topic> topicsRepository,
+    required PendingDeletionsService pendingDeletionsService,
+  }) : _topicsRepository = topicsRepository,
+       _pendingDeletionsService = pendingDeletionsService,
+       super(const DraftTopicsState()) {
+    on<LoadDraftTopicsRequested>(_onLoadDraftTopicsRequested);
+    on<PublishDraftTopicRequested>(_onPublishDraftTopicRequested);
+    on<_DeletionServiceStatusChanged>(
+      _onDeletionServiceStatusChanged,
+    );
+    on<DeleteDraftTopicForeverRequested>(
+      _onDeleteDraftTopicForeverRequested,
+    );
+    on<UndoDeleteDraftTopicRequested>(_onUndoDeleteDraftTopicRequested);
+    on<ClearPublishedTopic>(_onClearPublishedTopic);
+
+    // Listen to deletion events from the PendingDeletionsService.
+    // The filter now correctly checks the type of the item in the event.
+    _deletionEventSubscription = _pendingDeletionsService.deletionEvents.listen(
+      (event) {
+        if (event.item is Topic) {
+          add(_DeletionServiceStatusChanged(event));
+        }
+      },
+    );
+  }
+
+  final DataRepository<Topic> _topicsRepository;
+  final PendingDeletionsService _pendingDeletionsService;
+
+  /// Subscription to deletion events from the PendingDeletionsService.
+  late final StreamSubscription<DeletionEvent<dynamic>>
+  _deletionEventSubscription;
+
+  @override
+  Future<void> close() async {
+    // Cancel the subscription to deletion events to prevent memory leaks.
+    await _deletionEventSubscription.cancel();
+    return super.close();
+  }
+
+  /// Handles the request to load draft topics.
+  ///
+  /// Fetches paginated draft topics from the repository and updates the state.
+  Future<void> _onLoadDraftTopicsRequested(
+    LoadDraftTopicsRequested event,
+    Emitter<DraftTopicsState> emit,
+  ) async {
+    emit(state.copyWith(status: DraftTopicsStatus.loading));
+    try {
+      final isPaginating = event.startAfterId != null;
+      final previousTopics = isPaginating ? state.topics : <Topic>[];
+
+      final paginatedTopics = await _topicsRepository.readAll(
+        filter: {'status': ContentStatus.draft.name},
+        sort: [const SortOption('updatedAt', SortOrder.desc)],
+        pagination: PaginationOptions(
+          cursor: event.startAfterId,
+          limit: event.limit,
+        ),
+      );
+      emit(
+        state.copyWith(
+          status: DraftTopicsStatus.success,
+          topics: [...previousTopics, ...paginatedTopics.items],
+          cursor: paginatedTopics.cursor,
+          hasMore: paginatedTopics.hasMore,
+        ),
+      );
+    } on HttpException catch (e) {
+      emit(
+        state.copyWith(
+          status: DraftTopicsStatus.failure,
+          exception: e,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: DraftTopicsStatus.failure,
+          exception: UnknownException('An unexpected error occurred: $e'),
+        ),
+      );
+    }
+  }
+
+  /// Handles the request to publish a draft topic.
+  ///
+  /// Optimistically removes the topic from the UI, updates its status to active
+  /// in the repository, and then updates the state. If the topic was pending
+  /// deletion, its pending deletion is cancelled.
+  Future<void> _onPublishDraftTopicRequested(
+    PublishDraftTopicRequested event,
+    Emitter<DraftTopicsState> emit,
+  ) async {
+    final originalTopics = List<Topic>.from(state.topics);
+    final topicIndex = originalTopics.indexWhere((t) => t.id == event.id);
+    if (topicIndex == -1) return;
+
+    final topicToPublish = originalTopics[topicIndex];
+    final updatedTopics = originalTopics..removeAt(topicIndex);
+
+    // Optimistically remove the topic from the UI.
+    emit(
+      state.copyWith(
+        topics: updatedTopics,
+        lastPendingDeletionId: state.lastPendingDeletionId == event.id
+            ? null
+            : state.lastPendingDeletionId,
+        snackbarTopicTitle: null,
+      ),
+    );
+
+    try {
+      final publishedTopic = await _topicsRepository.update(
+        id: event.id,
+        item: topicToPublish.copyWith(status: ContentStatus.active),
+      );
+      emit(state.copyWith(publishedTopic: publishedTopic));
+    } on HttpException catch (e) {
+      // If the update fails, revert the change in the UI
+      emit(
+        state.copyWith(
+          topics: originalTopics,
+          exception: e,
+          lastPendingDeletionId: state.lastPendingDeletionId,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          topics: originalTopics,
+          exception: UnknownException('An unexpected error occurred: $e'),
+          lastPendingDeletionId: state.lastPendingDeletionId,
+        ),
+      );
+    }
+  }
+
+  /// Handles deletion events from the [PendingDeletionsService].
+  ///
+  /// This method is called when an item's deletion is confirmed or undone
+  /// by the service. It updates the BLoC's state accordingly.
+  Future<void> _onDeletionServiceStatusChanged(
+    _DeletionServiceStatusChanged event,
+    Emitter<DraftTopicsState> emit,
+  ) async {
+    final id = event.event.id;
+    final status = event.event.status;
+    final item = event.event.item;
+
+    if (status == DeletionStatus.confirmed) {
+      // Deletion confirmed, no action needed in BLoC as it was optimistically removed.
+      // Ensure lastPendingDeletionId and snackbarTopicTitle are cleared if this was the one.
+      emit(
+        state.copyWith(
+          lastPendingDeletionId: state.lastPendingDeletionId == id
+              ? null
+              : state.lastPendingDeletionId,
+          snackbarTopicTitle: null,
+        ),
+      );
+    } else if (status == DeletionStatus.undone) {
+      // Deletion undone, restore the topic to the main list.
+      if (item is Topic) {
+        final insertionIndex = state.topics.indexWhere(
+          (t) => t.updatedAt.isBefore(item.updatedAt),
+        );
+        final updatedTopics = List<Topic>.from(state.topics)
+          ..insert(
+            insertionIndex != -1 ? insertionIndex : state.topics.length,
+            item,
+          );
+        emit(
+          state.copyWith(
+            topics: updatedTopics,
+            lastPendingDeletionId: state.lastPendingDeletionId == id
+                ? null
+                : state.lastPendingDeletionId,
+            snackbarTopicTitle: null,
+          ),
+        );
+      }
+    }
+  }
+
+  /// Handles the request to permanently delete a draft topic.
+  ///
+  /// This optimistically removes the topic from the UI and initiates a
+  /// timed deletion via the [PendingDeletionsService].
+  Future<void> _onDeleteDraftTopicForeverRequested(
+    DeleteDraftTopicForeverRequested event,
+    Emitter<DraftTopicsState> emit,
+  ) async {
+    final topicToDelete = state.topics.firstWhere(
+      (t) => t.id == event.id,
+    );
+
+    // Optimistically remove the topic from the UI.
+    final updatedTopics = List<Topic>.from(state.topics)
+      ..removeWhere((t) => t.id == event.id);
+
+    emit(
+      state.copyWith(
+        topics: updatedTopics,
+        lastPendingDeletionId: event.id,
+        snackbarTopicTitle: topicToDelete.name,
+      ),
+    );
+
+    // Request deletion via the service.
+    _pendingDeletionsService.requestDeletion(
+      item: topicToDelete,
+      repository: _topicsRepository,
+      undoDuration: const Duration(seconds: 5),
+    );
+  }
+
+  /// Handles the request to undo a pending deletion of a draft topic.
+  ///
+  /// This cancels the deletion timer in the [PendingDeletionsService].
+  Future<void> _onUndoDeleteDraftTopicRequested(
+    UndoDeleteDraftTopicRequested event,
+    Emitter<DraftTopicsState> emit,
+  ) async {
+    _pendingDeletionsService.undoDeletion(event.id);
+    // The _onDeletionServiceStatusChanged will handle re-adding to the list
+    // and updating pendingDeletions when DeletionStatus.undone is emitted.
+  }
+
+  /// Handles the request to clear the published topic from the state.
+  ///
+  /// This is typically called after the UI has processed the published topic
+  /// and no longer needs it in the state.
+  void _onClearPublishedTopic(
+    ClearPublishedTopic event,
+    Emitter<DraftTopicsState> emit,
+  ) {
+    emit(state.copyWith(publishedTopic: null, snackbarTopicTitle: null));
+  }
+}

--- a/lib/content_management/bloc/draft_topics/draft_topics_event.dart
+++ b/lib/content_management/bloc/draft_topics/draft_topics_event.dart
@@ -1,0 +1,72 @@
+part of 'draft_topics_bloc.dart';
+
+sealed class DraftTopicsEvent extends Equatable {
+  const DraftTopicsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Event to request loading of draft topics.
+final class LoadDraftTopicsRequested extends DraftTopicsEvent {
+  const LoadDraftTopicsRequested({this.startAfterId, this.limit});
+
+  final String? startAfterId;
+  final int? limit;
+
+  @override
+  List<Object?> get props => [startAfterId, limit];
+}
+
+/// Event to publish a draft topic.
+final class PublishDraftTopicRequested extends DraftTopicsEvent {
+  const PublishDraftTopicRequested(this.id);
+
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+}
+
+/// Event to request permanent deletion of a draft topic.
+final class DeleteDraftTopicForeverRequested extends DraftTopicsEvent {
+  /// {@macro delete_draft_topic_forever_requested}
+  const DeleteDraftTopicForeverRequested(this.id);
+
+  /// The ID of the topic to permanently delete.
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+}
+
+/// Event to undo a pending deletion of a draft topic.
+final class UndoDeleteDraftTopicRequested extends DraftTopicsEvent {
+  /// {@macro undo_delete_draft_topic_requested}
+  const UndoDeleteDraftTopicRequested(this.id);
+
+  /// The ID of the topic whose deletion should be undone.
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+}
+
+/// Event to clear the published topic from the state.
+final class ClearPublishedTopic extends DraftTopicsEvent {
+  /// {@macro clear_published_topic}
+  const ClearPublishedTopic();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Event to handle updates from the pending deletions service.
+final class _DeletionServiceStatusChanged extends DraftTopicsEvent {
+  const _DeletionServiceStatusChanged(this.event);
+
+  final DeletionEvent<dynamic> event;
+
+  @override
+  List<Object?> get props => [event];
+}

--- a/lib/content_management/bloc/draft_topics/draft_topics_state.dart
+++ b/lib/content_management/bloc/draft_topics/draft_topics_state.dart
@@ -1,0 +1,101 @@
+part of 'draft_topics_bloc.dart';
+
+/// Represents the status of draft content operations.
+enum DraftTopicsStatus {
+  /// The operation is in its initial state.
+  initial,
+
+  /// Data is currently being loaded or an operation is in progress.
+  loading,
+
+  /// Data has been successfully loaded or an operation completed.
+  success,
+
+  /// An error occurred during data loading or an operation.
+  failure,
+}
+
+/// {@template draft_topics_state}
+/// The state for the draft content feature.
+///
+/// Manages the list of draft topics, pagination details,
+/// and any pending deletion operations.
+/// {@endtemplate}
+class DraftTopicsState extends Equatable {
+  /// {@macro draft_topics_state}
+  const DraftTopicsState({
+    this.status = DraftTopicsStatus.initial,
+    this.topics = const [],
+    this.cursor,
+    this.hasMore = false,
+    this.exception,
+    this.publishedTopic,
+    this.lastPendingDeletionId,
+    this.snackbarTopicTitle,
+  });
+
+  /// The current status of the draft topics operations.
+  final DraftTopicsStatus status;
+
+  /// The list of draft topics currently displayed.
+  final List<Topic> topics;
+
+  /// The cursor for fetching the next page of draft topics.
+  /// A `null` value indicates no more pages.
+  final String? cursor;
+
+  /// Indicates if there are more draft topics available to load.
+  final bool hasMore;
+
+  /// The exception encountered during a failed operation, if any.
+  final HttpException? exception;
+
+  /// The topic that was most recently published, if any.
+  final Topic? publishedTopic;
+
+  /// The ID of the topic that was most recently added to pending deletions.
+  /// Used to trigger the snackbar display.
+  final String? lastPendingDeletionId;
+
+  /// The title of the topic for which the snackbar should be displayed.
+  /// This is set when a deletion is requested and cleared when the snackbar
+  /// is no longer needed.
+  final String? snackbarTopicTitle;
+
+  /// Creates a copy of this [DraftTopicsState] with updated values.
+  DraftTopicsState copyWith({
+    DraftTopicsStatus? status,
+    List<Topic>? topics,
+    String? cursor,
+    bool? hasMore,
+    HttpException? exception,
+    Topic? publishedTopic,
+    String? lastPendingDeletionId,
+    String? snackbarTopicTitle,
+  }) {
+    return DraftTopicsState(
+      status: status ?? this.status,
+      topics: topics ?? this.topics,
+      cursor: cursor ?? this.cursor,
+      hasMore: hasMore ?? this.hasMore,
+      // Exception and publishedTopic are explicitly set to null if not provided
+      // to ensure they are cleared after being handled.
+      exception: exception,
+      publishedTopic: publishedTopic,
+      lastPendingDeletionId: lastPendingDeletionId,
+      snackbarTopicTitle: snackbarTopicTitle,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    status,
+    topics,
+    cursor,
+    hasMore,
+    exception,
+    publishedTopic,
+    lastPendingDeletionId,
+    snackbarTopicTitle,
+  ];
+}

--- a/lib/content_management/bloc/draft_topics/draft_topics_state.dart
+++ b/lib/content_management/bloc/draft_topics/draft_topics_state.dart
@@ -82,8 +82,9 @@ class DraftTopicsState extends Equatable {
       // to ensure they are cleared after being handled.
       exception: exception,
       publishedTopic: publishedTopic,
-      lastPendingDeletionId: lastPendingDeletionId,
-      snackbarTopicTitle: snackbarTopicTitle,
+      lastPendingDeletionId:
+          lastPendingDeletionId ?? this.lastPendingDeletionId,
+      snackbarTopicTitle: snackbarTopicTitle ?? this.snackbarTopicTitle,
     );
   }
 

--- a/lib/content_management/bloc/edit_headline/edit_headline_bloc.dart
+++ b/lib/content_management/bloc/edit_headline/edit_headline_bloc.dart
@@ -147,18 +147,6 @@ class EditHeadlineBloc extends Bloc<EditHeadlineEvent, EditHeadlineState> {
     EditHeadlineSavedAsDraft event,
     Emitter<EditHeadlineState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: EditHeadlineStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: EditHeadlineStatus.submitting));
     try {
       final originalHeadline = await _headlinesRepository.read(
@@ -203,18 +191,6 @@ class EditHeadlineBloc extends Bloc<EditHeadlineEvent, EditHeadlineState> {
     EditHeadlinePublished event,
     Emitter<EditHeadlineState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: EditHeadlineStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: EditHeadlineStatus.submitting));
     try {
       final originalHeadline = await _headlinesRepository.read(

--- a/lib/content_management/bloc/edit_headline/edit_headline_event.dart
+++ b/lib/content_management/bloc/edit_headline/edit_headline_event.dart
@@ -69,21 +69,6 @@ final class EditHeadlineCountryChanged extends EditHeadlineEvent {
   List<Object?> get props => [country];
 }
 
-/// Event for when the headline's status is changed.
-final class EditHeadlineStatusChanged extends EditHeadlineEvent {
-  const EditHeadlineStatusChanged(this.status);
-
-  final ContentStatus status;
-
-  @override
-  List<Object?> get props => [status];
-}
-
-/// Event to signal that the form should be submitted.
-final class EditHeadlineSubmitted extends EditHeadlineEvent {
-  const EditHeadlineSubmitted();
-}
-
 /// Event to save the headline as a draft.
 final class EditHeadlineSavedAsDraft extends EditHeadlineEvent {
   const EditHeadlineSavedAsDraft();

--- a/lib/content_management/bloc/edit_headline/edit_headline_state.dart
+++ b/lib/content_management/bloc/edit_headline/edit_headline_state.dart
@@ -30,7 +30,6 @@ final class EditHeadlineState extends Equatable {
     this.source,
     this.topic,
     this.eventCountry,
-    this.contentStatus = ContentStatus.active,
     this.exception,
     this.updatedHeadline,
   });
@@ -44,7 +43,6 @@ final class EditHeadlineState extends Equatable {
   final Source? source;
   final Topic? topic;
   final Country? eventCountry;
-  final ContentStatus contentStatus;
   final HttpException? exception;
   final Headline? updatedHeadline;
 
@@ -69,7 +67,6 @@ final class EditHeadlineState extends Equatable {
     ValueGetter<Source?>? source,
     ValueGetter<Topic?>? topic,
     ValueGetter<Country?>? eventCountry,
-    ContentStatus? contentStatus,
     HttpException? exception,
     Headline? updatedHeadline,
   }) {
@@ -83,7 +80,6 @@ final class EditHeadlineState extends Equatable {
       source: source != null ? source() : this.source,
       topic: topic != null ? topic() : this.topic,
       eventCountry: eventCountry != null ? eventCountry() : this.eventCountry,
-      contentStatus: contentStatus ?? this.contentStatus,
       exception: exception,
       updatedHeadline: updatedHeadline ?? this.updatedHeadline,
     );
@@ -100,7 +96,6 @@ final class EditHeadlineState extends Equatable {
     source,
     topic,
     eventCountry,
-    contentStatus,
     exception,
     updatedHeadline,
   ];

--- a/lib/content_management/bloc/edit_source/edit_source_bloc.dart
+++ b/lib/content_management/bloc/edit_source/edit_source_bloc.dart
@@ -130,18 +130,6 @@ class EditSourceBloc extends Bloc<EditSourceEvent, EditSourceState> {
     EditSourceSavedAsDraft event,
     Emitter<EditSourceState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: EditSourceStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: EditSourceStatus.submitting));
     try {
       final originalSource = await _sourcesRepository.read(id: state.sourceId);
@@ -183,18 +171,6 @@ class EditSourceBloc extends Bloc<EditSourceEvent, EditSourceState> {
     EditSourcePublished event,
     Emitter<EditSourceState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: EditSourceStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: EditSourceStatus.submitting));
     try {
       final originalSource = await _sourcesRepository.read(id: state.sourceId);

--- a/lib/content_management/bloc/edit_source/edit_source_bloc.dart
+++ b/lib/content_management/bloc/edit_source/edit_source_bloc.dart
@@ -24,8 +24,8 @@ class EditSourceBloc extends Bloc<EditSourceEvent, EditSourceState> {
     on<EditSourceTypeChanged>(_onSourceTypeChanged);
     on<EditSourceLanguageChanged>(_onLanguageChanged);
     on<EditSourceHeadquartersChanged>(_onHeadquartersChanged);
-    on<EditSourceStatusChanged>(_onStatusChanged);
-    on<EditSourceSubmitted>(_onSubmitted);
+    on<EditSourceSavedAsDraft>(_onSavedAsDraft);
+    on<EditSourcePublished>(_onPublished);
 
     add(const EditSourceLoaded());
   }
@@ -47,7 +47,6 @@ class EditSourceBloc extends Bloc<EditSourceEvent, EditSourceState> {
           sourceType: () => source.sourceType,
           language: () => source.language,
           headquarters: () => source.headquarters,
-          contentStatus: source.status,
         ),
       );
     } on HttpException catch (e) {
@@ -126,23 +125,22 @@ class EditSourceBloc extends Bloc<EditSourceEvent, EditSourceState> {
     );
   }
 
-  void _onStatusChanged(
-    EditSourceStatusChanged event,
-    Emitter<EditSourceState> emit,
-  ) {
-    emit(
-      state.copyWith(
-        contentStatus: event.status,
-        status: EditSourceStatus.initial,
-      ),
-    );
-  }
-
-  Future<void> _onSubmitted(
-    EditSourceSubmitted event,
+  /// Handles saving the source as a draft.
+  Future<void> _onSavedAsDraft(
+    EditSourceSavedAsDraft event,
     Emitter<EditSourceState> emit,
   ) async {
-    if (!state.isFormValid) return;
+    if (!state.isFormValid) {
+      emit(
+        state.copyWith(
+          status: EditSourceStatus.failure,
+          exception: const InvalidInputException(
+            'Form is not valid. Please complete all required fields.',
+          ),
+        ),
+      );
+      return;
+    }
 
     emit(state.copyWith(status: EditSourceStatus.submitting));
     try {
@@ -154,7 +152,60 @@ class EditSourceBloc extends Bloc<EditSourceEvent, EditSourceState> {
         sourceType: state.sourceType,
         language: state.language,
         headquarters: state.headquarters,
-        status: state.contentStatus,
+        status: ContentStatus.draft,
+        updatedAt: DateTime.now(),
+      );
+
+      await _sourcesRepository.update(
+        id: state.sourceId,
+        item: updatedSource,
+      );
+      emit(
+        state.copyWith(
+          status: EditSourceStatus.success,
+          updatedSource: updatedSource,
+        ),
+      );
+    } on HttpException catch (e) {
+      emit(state.copyWith(status: EditSourceStatus.failure, exception: e));
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: EditSourceStatus.failure,
+          exception: UnknownException('An unexpected error occurred: $e'),
+        ),
+      );
+    }
+  }
+
+  /// Handles publishing the source.
+  Future<void> _onPublished(
+    EditSourcePublished event,
+    Emitter<EditSourceState> emit,
+  ) async {
+    if (!state.isFormValid) {
+      emit(
+        state.copyWith(
+          status: EditSourceStatus.failure,
+          exception: const InvalidInputException(
+            'Form is not valid. Please complete all required fields.',
+          ),
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: EditSourceStatus.submitting));
+    try {
+      final originalSource = await _sourcesRepository.read(id: state.sourceId);
+      final updatedSource = originalSource.copyWith(
+        name: state.name,
+        description: state.description,
+        url: state.url,
+        sourceType: state.sourceType,
+        language: state.language,
+        headquarters: state.headquarters,
+        status: ContentStatus.active,
         updatedAt: DateTime.now(),
       );
 

--- a/lib/content_management/bloc/edit_source/edit_source_event.dart
+++ b/lib/content_management/bloc/edit_source/edit_source_event.dart
@@ -72,17 +72,12 @@ final class EditSourceHeadquartersChanged extends EditSourceEvent {
   List<Object?> get props => [headquarters];
 }
 
-/// Event for when the source's status is changed.
-final class EditSourceStatusChanged extends EditSourceEvent {
-  const EditSourceStatusChanged(this.status);
-
-  final ContentStatus status;
-
-  @override
-  List<Object?> get props => [status];
+/// Event to save the source as a draft.
+final class EditSourceSavedAsDraft extends EditSourceEvent {
+  const EditSourceSavedAsDraft();
 }
 
-/// Event to submit the edited source data.
-final class EditSourceSubmitted extends EditSourceEvent {
-  const EditSourceSubmitted();
+/// Event to publish the source.
+final class EditSourcePublished extends EditSourceEvent {
+  const EditSourcePublished();
 }

--- a/lib/content_management/bloc/edit_source/edit_source_state.dart
+++ b/lib/content_management/bloc/edit_source/edit_source_state.dart
@@ -29,7 +29,6 @@ final class EditSourceState extends Equatable {
     this.sourceType,
     this.language,
     this.headquarters,
-    this.contentStatus = ContentStatus.active,
     this.exception,
     this.updatedSource,
   });
@@ -42,7 +41,6 @@ final class EditSourceState extends Equatable {
   final SourceType? sourceType;
   final Language? language;
   final Country? headquarters;
-  final ContentStatus contentStatus;
   final HttpException? exception;
   final Source? updatedSource;
 
@@ -65,7 +63,6 @@ final class EditSourceState extends Equatable {
     ValueGetter<SourceType?>? sourceType,
     ValueGetter<Language?>? language,
     ValueGetter<Country?>? headquarters,
-    ContentStatus? contentStatus,
     HttpException? exception,
     Source? updatedSource,
   }) {
@@ -78,7 +75,6 @@ final class EditSourceState extends Equatable {
       sourceType: sourceType != null ? sourceType() : this.sourceType,
       language: language != null ? language() : this.language,
       headquarters: headquarters != null ? headquarters() : this.headquarters,
-      contentStatus: contentStatus ?? this.contentStatus,
       exception: exception,
       updatedSource: updatedSource ?? this.updatedSource,
     );
@@ -94,7 +90,6 @@ final class EditSourceState extends Equatable {
     sourceType,
     language,
     headquarters,
-    contentStatus,
     exception,
     updatedSource,
   ];

--- a/lib/content_management/bloc/edit_topic/edit_topic_bloc.dart
+++ b/lib/content_management/bloc/edit_topic/edit_topic_bloc.dart
@@ -20,8 +20,8 @@ class EditTopicBloc extends Bloc<EditTopicEvent, EditTopicState> {
     on<EditTopicNameChanged>(_onNameChanged);
     on<EditTopicDescriptionChanged>(_onDescriptionChanged);
     on<EditTopicIconUrlChanged>(_onIconUrlChanged);
-    on<EditTopicStatusChanged>(_onStatusChanged);
-    on<EditTopicSubmitted>(_onSubmitted);
+    on<EditTopicSavedAsDraft>(_onSavedAsDraft);
+    on<EditTopicPublished>(_onPublished);
 
     add(const EditTopicLoaded());
   }
@@ -40,7 +40,6 @@ class EditTopicBloc extends Bloc<EditTopicEvent, EditTopicState> {
           name: topic.name,
           description: topic.description,
           iconUrl: topic.iconUrl,
-          contentStatus: topic.status,
         ),
       );
     } on HttpException catch (e) {
@@ -85,23 +84,22 @@ class EditTopicBloc extends Bloc<EditTopicEvent, EditTopicState> {
     );
   }
 
-  void _onStatusChanged(
-    EditTopicStatusChanged event,
-    Emitter<EditTopicState> emit,
-  ) {
-    emit(
-      state.copyWith(
-        contentStatus: event.status,
-        status: EditTopicStatus.initial,
-      ),
-    );
-  }
-
-  Future<void> _onSubmitted(
-    EditTopicSubmitted event,
+  /// Handles saving the topic as a draft.
+  Future<void> _onSavedAsDraft(
+    EditTopicSavedAsDraft event,
     Emitter<EditTopicState> emit,
   ) async {
-    if (!state.isFormValid) return;
+    if (!state.isFormValid) {
+      emit(
+        state.copyWith(
+          status: EditTopicStatus.failure,
+          exception: const InvalidInputException(
+            'Form is not valid. Please complete all required fields.',
+          ),
+        ),
+      );
+      return;
+    }
 
     emit(state.copyWith(status: EditTopicStatus.submitting));
     try {
@@ -110,7 +108,54 @@ class EditTopicBloc extends Bloc<EditTopicEvent, EditTopicState> {
         name: state.name,
         description: state.description,
         iconUrl: state.iconUrl,
-        status: state.contentStatus,
+        status: ContentStatus.draft,
+        updatedAt: DateTime.now(),
+      );
+
+      await _topicsRepository.update(id: state.topicId, item: updatedTopic);
+      emit(
+        state.copyWith(
+          status: EditTopicStatus.success,
+          updatedTopic: updatedTopic,
+        ),
+      );
+    } on HttpException catch (e) {
+      emit(state.copyWith(status: EditTopicStatus.failure, exception: e));
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: EditTopicStatus.failure,
+          exception: UnknownException('An unexpected error occurred: $e'),
+        ),
+      );
+    }
+  }
+
+  /// Handles publishing the topic.
+  Future<void> _onPublished(
+    EditTopicPublished event,
+    Emitter<EditTopicState> emit,
+  ) async {
+    if (!state.isFormValid) {
+      emit(
+        state.copyWith(
+          status: EditTopicStatus.failure,
+          exception: const InvalidInputException(
+            'Form is not valid. Please complete all required fields.',
+          ),
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: EditTopicStatus.submitting));
+    try {
+      final originalTopic = await _topicsRepository.read(id: state.topicId);
+      final updatedTopic = originalTopic.copyWith(
+        name: state.name,
+        description: state.description,
+        iconUrl: state.iconUrl,
+        status: ContentStatus.active,
         updatedAt: DateTime.now(),
       );
 

--- a/lib/content_management/bloc/edit_topic/edit_topic_bloc.dart
+++ b/lib/content_management/bloc/edit_topic/edit_topic_bloc.dart
@@ -89,18 +89,6 @@ class EditTopicBloc extends Bloc<EditTopicEvent, EditTopicState> {
     EditTopicSavedAsDraft event,
     Emitter<EditTopicState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: EditTopicStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: EditTopicStatus.submitting));
     try {
       final originalTopic = await _topicsRepository.read(id: state.topicId);
@@ -136,18 +124,6 @@ class EditTopicBloc extends Bloc<EditTopicEvent, EditTopicState> {
     EditTopicPublished event,
     Emitter<EditTopicState> emit,
   ) async {
-    if (!state.isFormValid) {
-      emit(
-        state.copyWith(
-          status: EditTopicStatus.failure,
-          exception: const InvalidInputException(
-            'Form is not valid. Please complete all required fields.',
-          ),
-        ),
-      );
-      return;
-    }
-
     emit(state.copyWith(status: EditTopicStatus.submitting));
     try {
       final originalTopic = await _topicsRepository.read(id: state.topicId);

--- a/lib/content_management/bloc/edit_topic/edit_topic_event.dart
+++ b/lib/content_management/bloc/edit_topic/edit_topic_event.dart
@@ -43,17 +43,12 @@ final class EditTopicIconUrlChanged extends EditTopicEvent {
   List<Object?> get props => [iconUrl];
 }
 
-/// Event for when the topic's status is changed.
-final class EditTopicStatusChanged extends EditTopicEvent {
-  const EditTopicStatusChanged(this.status);
-
-  final ContentStatus status;
-
-  @override
-  List<Object?> get props => [status];
+/// Event to save the topic as a draft.
+final class EditTopicSavedAsDraft extends EditTopicEvent {
+  const EditTopicSavedAsDraft();
 }
 
-/// Event to submit the edited topic data.
-final class EditTopicSubmitted extends EditTopicEvent {
-  const EditTopicSubmitted();
+/// Event to publish the topic.
+final class EditTopicPublished extends EditTopicEvent {
+  const EditTopicPublished();
 }

--- a/lib/content_management/bloc/edit_topic/edit_topic_state.dart
+++ b/lib/content_management/bloc/edit_topic/edit_topic_state.dart
@@ -8,7 +8,7 @@ enum EditTopicStatus {
   /// Data is being loaded.
   loading,
 
-  /// Data has been successfully loaded or an operation completed.
+  /// An operation completed successfully.
   success,
 
   /// An error occurred.
@@ -26,7 +26,6 @@ final class EditTopicState extends Equatable {
     this.name = '',
     this.description = '',
     this.iconUrl = '',
-    this.contentStatus = ContentStatus.active,
     this.exception,
     this.updatedTopic,
   });
@@ -36,7 +35,6 @@ final class EditTopicState extends Equatable {
   final String name;
   final String description;
   final String iconUrl;
-  final ContentStatus contentStatus;
   final HttpException? exception;
   final Topic? updatedTopic;
 
@@ -54,7 +52,6 @@ final class EditTopicState extends Equatable {
     String? name,
     String? description,
     String? iconUrl,
-    ContentStatus? contentStatus,
     HttpException? exception,
     Topic? updatedTopic,
   }) {
@@ -64,7 +61,6 @@ final class EditTopicState extends Equatable {
       name: name ?? this.name,
       description: description ?? this.description,
       iconUrl: iconUrl ?? this.iconUrl,
-      contentStatus: contentStatus ?? this.contentStatus,
       exception: exception ?? this.exception,
       updatedTopic: updatedTopic ?? this.updatedTopic,
     );
@@ -77,7 +73,6 @@ final class EditTopicState extends Equatable {
     name,
     description,
     iconUrl,
-    contentStatus,
     exception,
     updatedTopic,
   ];

--- a/lib/content_management/view/content_management_page.dart
+++ b/lib/content_management/view/content_management_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/bloc/content_management_bloc.dart';
-import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/draft_headlines_page.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/headlines_page.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/sources_page.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/topics_page.dart';

--- a/lib/content_management/view/content_management_page.dart
+++ b/lib/content_management/view/content_management_page.dart
@@ -96,7 +96,7 @@ class _ContentManagementPageState extends State<ContentManagementPage>
           ),
           actions: [
             IconButton(
-              icon: const Icon(Icons.edit_note),
+              icon: const Icon(Icons.drafts_outlined),
               tooltip: l10n.draftsIconTooltip,
               onPressed: () {
                 final currentTab = context
@@ -114,7 +114,7 @@ class _ContentManagementPageState extends State<ContentManagementPage>
               },
             ),
             IconButton(
-              icon: const Icon(Icons.inventory_2_outlined),
+              icon: const Icon(Icons.archive_outlined),
               tooltip: l10n.archivedItems,
               onPressed: () {
                 final currentTab = context
@@ -132,7 +132,7 @@ class _ContentManagementPageState extends State<ContentManagementPage>
               },
             ),
             IconButton(
-              icon: const Icon(Icons.add),
+              icon: const Icon(Icons.add_outlined),
               tooltip: l10n.addNewItem,
               onPressed: () {
                 final currentTab = context

--- a/lib/content_management/view/content_management_page.dart
+++ b/lib/content_management/view/content_management_page.dart
@@ -107,10 +107,8 @@ class _ContentManagementPageState extends State<ContentManagementPage>
                   case ContentManagementTab.headlines:
                     context.goNamed(Routes.draftHeadlinesName);
                   case ContentManagementTab.topics:
-                    // Placeholder for Draft Topics Page
                     context.goNamed(Routes.draftTopicsName);
                   case ContentManagementTab.sources:
-                    // Placeholder for Draft Sources Page
                     context.goNamed(Routes.draftSourcesName);
                 }
               },

--- a/lib/content_management/view/create_headline_page.dart
+++ b/lib/content_management/view/create_headline_page.dart
@@ -60,36 +60,6 @@ class _CreateHeadlineViewState extends State<_CreateHeadlineView> {
     super.dispose();
   }
 
-  /// Shows a dialog to the user when the form is invalid, offering options
-  /// to complete the form or discard changes.
-  Future<void> _showInvalidFormDialog(BuildContext context) async {
-    final l10n = AppLocalizationsX(context).l10n;
-    final result = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.invalidFormTitle),
-        content: Text(l10n.invalidFormMessage),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(l10n.completeForm),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(l10n.discard),
-          ),
-        ],
-      ),
-    );
-
-    if (result ?? false) {
-      // If user chooses to discard, pop the page.
-      if (context.mounted) {
-        context.pop();
-      }
-    }
-  }
-
   /// Shows a dialog to the user to choose between publishing or saving as draft.
   Future<ContentStatus?> _showSaveOptionsDialog(BuildContext context) async {
     final l10n = AppLocalizationsX(context).l10n;
@@ -131,27 +101,28 @@ class _CreateHeadlineViewState extends State<_CreateHeadlineView> {
                   ),
                 );
               }
+              // The save button is enabled only if the form is valid.
               return IconButton(
                 icon: const Icon(Icons.save),
                 tooltip: l10n.saveChanges,
-                onPressed: () async {
-                  if (state.isFormValid) {
-                    final selectedStatus = await _showSaveOptionsDialog(
-                      context,
-                    );
-                    if (selectedStatus == ContentStatus.active) {
-                      context.read<CreateHeadlineBloc>().add(
-                        const CreateHeadlinePublished(),
-                      );
-                    } else if (selectedStatus == ContentStatus.draft) {
-                      context.read<CreateHeadlineBloc>().add(
-                        const CreateHeadlineSavedAsDraft(),
-                      );
-                    }
-                  } else {
-                    await _showInvalidFormDialog(context);
-                  }
-                },
+                onPressed: state.isFormValid
+                    ? () async {
+                        final selectedStatus = await _showSaveOptionsDialog(
+                          context,
+                        );
+                        if (selectedStatus == ContentStatus.active &&
+                            context.mounted) {
+                          context.read<CreateHeadlineBloc>().add(
+                            const CreateHeadlinePublished(),
+                          );
+                        } else if (selectedStatus == ContentStatus.draft &&
+                            context.mounted) {
+                          context.read<CreateHeadlineBloc>().add(
+                            const CreateHeadlineSavedAsDraft(),
+                          );
+                        }
+                      }
+                    : null, // Disable button if form is not valid
               );
             },
           ),

--- a/lib/content_management/view/create_headline_page.dart
+++ b/lib/content_management/view/create_headline_page.dart
@@ -90,6 +90,28 @@ class _CreateHeadlineViewState extends State<_CreateHeadlineView> {
     }
   }
 
+  /// Shows a dialog to the user to choose between publishing or saving as draft.
+  Future<ContentStatus?> _showSaveOptionsDialog(BuildContext context) async {
+    final l10n = AppLocalizationsX(context).l10n;
+    return showDialog<ContentStatus>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.saveHeadlineTitle),
+        content: Text(l10n.saveHeadlineMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(ContentStatus.draft),
+            child: Text(l10n.saveAsDraft),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(ContentStatus.active),
+            child: Text(l10n.publish),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizationsX(context).l10n;
@@ -109,35 +131,27 @@ class _CreateHeadlineViewState extends State<_CreateHeadlineView> {
                   ),
                 );
               }
-              return Row(
-                children: [
-                  TextButton(
-                    onPressed: () async {
-                      if (state.isFormValid) {
-                        context.read<CreateHeadlineBloc>().add(
-                          const CreateHeadlinePublished(),
-                        );
-                      } else {
-                        await _showInvalidFormDialog(context);
-                      }
-                    },
-                    child: Text(l10n.publish),
-                  ),
-                  const SizedBox(width: AppSpacing.md),
-                  ElevatedButton(
-                    onPressed: () async {
-                      if (state.isFormValid) {
-                        context.read<CreateHeadlineBloc>().add(
-                          const CreateHeadlineSavedAsDraft(),
-                        );
-                      } else {
-                        await _showInvalidFormDialog(context);
-                      }
-                    },
-                    child: Text(l10n.saveAsDraft),
-                  ),
-                  const SizedBox(width: AppSpacing.lg),
-                ],
+              return IconButton(
+                icon: const Icon(Icons.save),
+                tooltip: l10n.saveChanges,
+                onPressed: () async {
+                  if (state.isFormValid) {
+                    final selectedStatus = await _showSaveOptionsDialog(
+                      context,
+                    );
+                    if (selectedStatus == ContentStatus.active) {
+                      context.read<CreateHeadlineBloc>().add(
+                        const CreateHeadlinePublished(),
+                      );
+                    } else if (selectedStatus == ContentStatus.draft) {
+                      context.read<CreateHeadlineBloc>().add(
+                        const CreateHeadlineSavedAsDraft(),
+                      );
+                    }
+                  } else {
+                    await _showInvalidFormDialog(context);
+                  }
+                },
               );
             },
           ),
@@ -305,22 +319,6 @@ class _CreateHeadlineViewState extends State<_CreateHeadlineView> {
                         SortOption('name', SortOrder.asc),
                       ],
                       limit: kDefaultRowsPerPage,
-                      includeInactiveSelectedItem: false,
-                    ),
-                    const SizedBox(height: AppSpacing.lg),
-                    SearchableSelectionInput<ContentStatus>(
-                      label: l10n.status,
-                      selectedItem: state.contentStatus,
-                      staticItems: ContentStatus.values.toList(),
-                      itemBuilder: (context, status) =>
-                          Text(status.l10n(context)),
-                      itemToString: (status) => status.l10n(context),
-                      onChanged: (value) {
-                        if (value == null) return;
-                        context.read<CreateHeadlineBloc>().add(
-                          CreateHeadlineStatusChanged(value),
-                        );
-                      },
                       includeInactiveSelectedItem: false,
                     ),
                   ],

--- a/lib/content_management/view/create_source_page.dart
+++ b/lib/content_management/view/create_source_page.dart
@@ -57,36 +57,6 @@ class _CreateSourceViewState extends State<_CreateSourceView> {
     super.dispose();
   }
 
-  /// Shows a dialog to the user when the form is invalid, offering options
-  /// to complete the form or discard changes.
-  Future<void> _showInvalidFormDialog(BuildContext context) async {
-    final l10n = AppLocalizationsX(context).l10n;
-    final result = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.invalidFormTitle),
-        content: Text(l10n.invalidFormMessage),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(l10n.completeForm),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(l10n.discard),
-          ),
-        ],
-      ),
-    );
-
-    if (result ?? false) {
-      // If user chooses to discard, pop the page.
-      if (context.mounted) {
-        context.pop();
-      }
-    }
-  }
-
   /// Shows a dialog to the user to choose between publishing or saving as draft.
   Future<ContentStatus?> _showSaveOptionsDialog(BuildContext context) async {
     final l10n = AppLocalizationsX(context).l10n;
@@ -128,27 +98,28 @@ class _CreateSourceViewState extends State<_CreateSourceView> {
                   ),
                 );
               }
+              // The save button is enabled only if the form is valid.
               return IconButton(
                 icon: const Icon(Icons.save),
                 tooltip: l10n.saveChanges,
-                onPressed: () async {
-                  if (state.isFormValid) {
-                    final selectedStatus = await _showSaveOptionsDialog(
-                      context,
-                    );
-                    if (selectedStatus == ContentStatus.active) {
-                      context.read<CreateSourceBloc>().add(
-                        const CreateSourcePublished(),
-                      );
-                    } else if (selectedStatus == ContentStatus.draft) {
-                      context.read<CreateSourceBloc>().add(
-                        const CreateSourceSavedAsDraft(),
-                      );
-                    }
-                  } else {
-                    await _showInvalidFormDialog(context);
-                  }
-                },
+                onPressed: state.isFormValid
+                    ? () async {
+                        final selectedStatus = await _showSaveOptionsDialog(
+                          context,
+                        );
+                        if (selectedStatus == ContentStatus.active &&
+                            context.mounted) {
+                          context.read<CreateSourceBloc>().add(
+                            const CreateSourcePublished(),
+                          );
+                        } else if (selectedStatus == ContentStatus.draft &&
+                            context.mounted) {
+                          context.read<CreateSourceBloc>().add(
+                            const CreateSourceSavedAsDraft(),
+                          );
+                        }
+                      }
+                    : null, // Disable button if form is not valid
               );
             },
           ),
@@ -190,10 +161,6 @@ class _CreateSourceViewState extends State<_CreateSourceView> {
           if (state.status == CreateSourceStatus.failure) {
             return FailureStateWidget(
               exception: state.exception!,
-              // TODO(fulleni): fix teh commented lines below
-              // onRetry: () => context.read<CreateSourceBloc>().add(
-              //   const CreateSourceLoadRequested(), // Changed to LoadRequested
-              // ),
             );
           }
 

--- a/lib/content_management/view/create_source_page.dart
+++ b/lib/content_management/view/create_source_page.dart
@@ -159,9 +159,14 @@ class _CreateSourceViewState extends State<_CreateSourceView> {
           }
 
           if (state.status == CreateSourceStatus.failure) {
-            return FailureStateWidget(
-              exception: state.exception!,
-            );
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(
+                SnackBar(
+                  content: Text(state.exception!.toFriendlyMessage(context)),
+                  backgroundColor: Theme.of(context).colorScheme.error,
+                ),
+              );
           }
 
           return SingleChildScrollView(

--- a/lib/content_management/view/create_topic_page.dart
+++ b/lib/content_management/view/create_topic_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/bloc/content_management_bloc.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/bloc/create_topic/create_topic_bloc.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
-import 'package:flutter_news_app_web_dashboard_full_source_code/shared/shared.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ui_kit/ui_kit.dart';
 
@@ -37,6 +36,78 @@ class _CreateTopicView extends StatefulWidget {
 
 class _CreateTopicViewState extends State<_CreateTopicView> {
   final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _descriptionController;
+  late final TextEditingController _iconUrlController;
+
+  @override
+  void initState() {
+    super.initState();
+    final state = context.read<CreateTopicBloc>().state;
+    _nameController = TextEditingController(text: state.name);
+    _descriptionController = TextEditingController(text: state.description);
+    _iconUrlController = TextEditingController(text: state.iconUrl);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    _iconUrlController.dispose();
+    super.dispose();
+  }
+
+  /// Shows a dialog to the user when the form is invalid, offering options
+  /// to complete the form or discard changes.
+  Future<void> _showInvalidFormDialog(BuildContext context) async {
+    final l10n = AppLocalizationsX(context).l10n;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.invalidFormTitle),
+        content: Text(l10n.invalidFormMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.completeForm),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.discard),
+          ),
+        ],
+      ),
+    );
+
+    if (result ?? false) {
+      // If user chooses to discard, pop the page.
+      if (context.mounted) {
+        context.pop();
+      }
+    }
+  }
+
+  /// Shows a dialog to the user to choose between publishing or saving as draft.
+  Future<ContentStatus?> _showSaveOptionsDialog(BuildContext context) async {
+    final l10n = AppLocalizationsX(context).l10n;
+    return showDialog<ContentStatus>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.saveTopicTitle),
+        content: Text(l10n.saveTopicMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(ContentStatus.draft),
+            child: Text(l10n.saveAsDraft),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(ContentStatus.active),
+            child: Text(l10n.publish),
+          ),
+        ],
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -60,11 +131,24 @@ class _CreateTopicViewState extends State<_CreateTopicView> {
               return IconButton(
                 icon: const Icon(Icons.save),
                 tooltip: l10n.saveChanges,
-                onPressed: state.isFormValid
-                    ? () => context.read<CreateTopicBloc>().add(
-                        const CreateTopicSubmitted(),
-                      )
-                    : null,
+                onPressed: () async {
+                  if (state.isFormValid) {
+                    final selectedStatus = await _showSaveOptionsDialog(
+                      context,
+                    );
+                    if (selectedStatus == ContentStatus.active) {
+                      context.read<CreateTopicBloc>().add(
+                        const CreateTopicPublished(),
+                      );
+                    } else if (selectedStatus == ContentStatus.draft) {
+                      context.read<CreateTopicBloc>().add(
+                        const CreateTopicSavedAsDraft(),
+                      );
+                    }
+                  } else {
+                    await _showInvalidFormDialog(context);
+                  }
+                },
               );
             },
           ),
@@ -108,7 +192,7 @@ class _CreateTopicViewState extends State<_CreateTopicView> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     TextFormField(
-                      initialValue: state.name,
+                      controller: _nameController,
                       decoration: InputDecoration(
                         labelText: l10n.topicName,
                         border: const OutlineInputBorder(),
@@ -119,7 +203,7 @@ class _CreateTopicViewState extends State<_CreateTopicView> {
                     ),
                     const SizedBox(height: AppSpacing.lg),
                     TextFormField(
-                      initialValue: state.description,
+                      controller: _descriptionController,
                       decoration: InputDecoration(
                         labelText: l10n.description,
                         border: const OutlineInputBorder(),
@@ -131,7 +215,7 @@ class _CreateTopicViewState extends State<_CreateTopicView> {
                     ),
                     const SizedBox(height: AppSpacing.lg),
                     TextFormField(
-                      initialValue: state.iconUrl,
+                      controller: _iconUrlController,
                       decoration: InputDecoration(
                         labelText: l10n.iconUrl,
                         border: const OutlineInputBorder(),
@@ -139,21 +223,6 @@ class _CreateTopicViewState extends State<_CreateTopicView> {
                       onChanged: (value) => context.read<CreateTopicBloc>().add(
                         CreateTopicIconUrlChanged(value),
                       ),
-                    ),
-                    const SizedBox(height: AppSpacing.lg),
-                    SearchableSelectionInput<ContentStatus>(
-                      label: l10n.status,
-                      selectedItem: state.contentStatus,
-                      staticItems: ContentStatus.values.toList(),
-                      itemBuilder: (context, status) =>
-                          Text(status.l10n(context)),
-                      itemToString: (status) => status.l10n(context),
-                      onChanged: (value) {
-                        if (value == null) return;
-                        context.read<CreateTopicBloc>().add(
-                          CreateTopicStatusChanged(value),
-                        );
-                      },
                     ),
                   ],
                 ),

--- a/lib/content_management/view/draft_sources_page.dart
+++ b/lib/content_management/view/draft_sources_page.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
+
+/// {@template draft_sources_page}
+/// A placeholder page for displaying draft sources.
+/// {@endtemplate}
+class DraftSourcesPage extends StatelessWidget {
+  /// {@macro draft_sources_page}
+  const DraftSourcesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.draftSources),
+      ),
+      body: Center(
+        child: Text(l10n.draftSources),
+      ),
+    );
+  }
+}

--- a/lib/content_management/view/draft_sources_page.dart
+++ b/lib/content_management/view/draft_sources_page.dart
@@ -1,8 +1,21 @@
+import 'package:core/core.dart';
+import 'package:data_repository/data_repository.dart';
+import 'package:data_table_2/data_table_2.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/bloc/content_management_bloc.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/bloc/draft_sources/draft_sources_bloc.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/app_localizations.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/router/routes.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/extensions.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/shared/services/pending_deletions_service.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:ui_kit/ui_kit.dart';
 
 /// {@template draft_sources_page}
-/// A placeholder page for displaying draft sources.
+/// A page for displaying and managing draft sources in a tabular format.
 /// {@endtemplate}
 class DraftSourcesPage extends StatelessWidget {
   /// {@macro draft_sources_page}
@@ -10,14 +23,230 @@ class DraftSourcesPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = context.l10n;
+    final l10n = AppLocalizationsX(context).l10n;
+    final pendingDeletionsService = context.read<PendingDeletionsService>();
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.draftSources),
       ),
-      body: Center(
-        child: Text(l10n.draftSources),
+      body: BlocProvider(
+        create: (context) => DraftSourcesBloc(
+          sourcesRepository: context.read<DataRepository<Source>>(),
+          pendingDeletionsService: pendingDeletionsService,
+        )..add(const LoadDraftSourcesRequested(limit: kDefaultRowsPerPage)),
+        child: BlocListener<DraftSourcesBloc, DraftSourcesState>(
+          listenWhen: (previous, current) =>
+              previous.lastPendingDeletionId != current.lastPendingDeletionId ||
+              previous.publishedSource != current.publishedSource ||
+              previous.snackbarSourceTitle != current.snackbarSourceTitle,
+          listener: (context, state) {
+            if (state.publishedSource != null) {
+              // When a source is published, refresh the main sources list.
+              context.read<ContentManagementBloc>().add(
+                const LoadSourcesRequested(limit: kDefaultRowsPerPage),
+              );
+              // Clear the publishedSource after it's been handled.
+              context.read<DraftSourcesBloc>().add(
+                const ClearPublishedSource(),
+              );
+            }
+
+            // Show snackbar for pending deletions.
+            if (state.snackbarSourceTitle != null) {
+              final sourceId = state.lastPendingDeletionId!;
+              final truncatedTitle = state.snackbarSourceTitle!.truncate(30);
+              ScaffoldMessenger.of(context)
+                ..hideCurrentSnackBar()
+                ..showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      l10n.sourceDeleted(truncatedTitle),
+                    ),
+                    action: SnackBarAction(
+                      label: l10n.undo,
+                      onPressed: () {
+                        // Directly call undoDeletion on the service.
+                        pendingDeletionsService.undoDeletion(sourceId);
+                      },
+                    ),
+                  ),
+                );
+            }
+          },
+          child: BlocBuilder<DraftSourcesBloc, DraftSourcesState>(
+            builder: (context, state) {
+              if (state.status == DraftSourcesStatus.loading &&
+                  state.sources.isEmpty) {
+                return LoadingStateWidget(
+                  icon: Icons.edit_note,
+                  headline: l10n.loadingDraftSources,
+                  subheadline: l10n.pleaseWait,
+                );
+              }
+
+              if (state.status == DraftSourcesStatus.failure) {
+                return FailureStateWidget(
+                  exception: state.exception!,
+                  onRetry: () => context.read<DraftSourcesBloc>().add(
+                    const LoadDraftSourcesRequested(
+                      limit: kDefaultRowsPerPage,
+                    ),
+                  ),
+                );
+              }
+
+              if (state.sources.isEmpty) {
+                return Center(child: Text(l10n.noDraftSourcesFound));
+              }
+
+              return Column(
+                children: [
+                  if (state.status == DraftSourcesStatus.loading &&
+                      state.sources.isNotEmpty)
+                    const LinearProgressIndicator(),
+                  Expanded(
+                    child: PaginatedDataTable2(
+                      columns: [
+                        DataColumn2(
+                          label: Text(l10n.sourceName),
+                          size: ColumnSize.L,
+                        ),
+                        DataColumn2(
+                          label: Text(l10n.lastUpdated),
+                          size: ColumnSize.M,
+                        ),
+                        DataColumn2(
+                          label: Text(l10n.actions),
+                          size: ColumnSize.S,
+                          fixedWidth: 120,
+                        ),
+                      ],
+                      source: _DraftSourcesDataSource(
+                        context: context,
+                        sources: state.sources,
+                        hasMore: state.hasMore,
+                        l10n: l10n,
+                      ),
+                      rowsPerPage: kDefaultRowsPerPage,
+                      availableRowsPerPage: const [kDefaultRowsPerPage],
+                      onPageChanged: (pageIndex) {
+                        final newOffset = pageIndex * kDefaultRowsPerPage;
+                        if (newOffset >= state.sources.length &&
+                            state.hasMore &&
+                            state.status != DraftSourcesStatus.loading) {
+                          context.read<DraftSourcesBloc>().add(
+                            LoadDraftSourcesRequested(
+                              startAfterId: state.cursor,
+                              limit: kDefaultRowsPerPage,
+                            ),
+                          );
+                        }
+                      },
+                      empty: Center(child: Text(l10n.noSourcesFound)),
+                      showCheckboxColumn: false,
+                      showFirstLastButtons: true,
+                      fit: FlexFit.tight,
+                      headingRowHeight: 56,
+                      dataRowHeight: 56,
+                      columnSpacing: AppSpacing.md,
+                      horizontalMargin: AppSpacing.md,
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
       ),
     );
   }
+}
+
+class _DraftSourcesDataSource extends DataTableSource {
+  _DraftSourcesDataSource({
+    required this.context,
+    required this.sources,
+    required this.hasMore,
+    required this.l10n,
+  });
+
+  final BuildContext context;
+  final List<Source> sources;
+  final bool hasMore;
+  final AppLocalizations l10n;
+
+  @override
+  DataRow? getRow(int index) {
+    if (index >= sources.length) {
+      return null;
+    }
+    final source = sources[index];
+    return DataRow2(
+      onSelectChanged: (selected) {
+        if (selected ?? false) {
+          context.goNamed(
+            Routes.editSourceName,
+            pathParameters: {'id': source.id},
+          );
+        }
+      },
+      cells: [
+        DataCell(
+          Text(
+            source.name,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        DataCell(
+          Text(
+            DateFormat('dd-MM-yyyy').format(source.updatedAt.toLocal()),
+          ),
+        ),
+        DataCell(
+          Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.publish),
+                tooltip: l10n.publish,
+                onPressed: () {
+                  context.read<DraftSourcesBloc>().add(
+                    PublishDraftSourceRequested(source.id),
+                  );
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.edit),
+                tooltip: l10n.editSource,
+                onPressed: () {
+                  context.goNamed(
+                    Routes.editSourceName,
+                    pathParameters: {'id': source.id},
+                  );
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete_forever),
+                tooltip: l10n.deleteForever,
+                onPressed: () {
+                  context.read<DraftSourcesBloc>().add(
+                    DeleteDraftSourceForeverRequested(source.id),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  bool get isRowCountApproximate => hasMore;
+
+  @override
+  int get rowCount => sources.length;
+
+  @override
+  int get selectedRowCount => 0;
 }

--- a/lib/content_management/view/draft_topics_page.dart
+++ b/lib/content_management/view/draft_topics_page.dart
@@ -1,8 +1,21 @@
+import 'package:core/core.dart';
+import 'package:data_repository/data_repository.dart';
+import 'package:data_table_2/data_table_2.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/bloc/content_management_bloc.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/bloc/draft_topics/draft_topics_bloc.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/app_localizations.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/router/routes.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/extensions.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/shared/services/pending_deletions_service.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:ui_kit/ui_kit.dart';
 
 /// {@template draft_topics_page}
-/// A placeholder page for displaying draft topics.
+/// A page for displaying and managing draft topics in a tabular format.
 /// {@endtemplate}
 class DraftTopicsPage extends StatelessWidget {
   /// {@macro draft_topics_page}
@@ -10,14 +23,230 @@ class DraftTopicsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = context.l10n;
+    final l10n = AppLocalizationsX(context).l10n;
+    final pendingDeletionsService = context.read<PendingDeletionsService>();
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.draftTopics),
       ),
-      body: Center(
-        child: Text(l10n.draftTopics),
+      body: BlocProvider(
+        create: (context) => DraftTopicsBloc(
+          topicsRepository: context.read<DataRepository<Topic>>(),
+          pendingDeletionsService: pendingDeletionsService,
+        )..add(const LoadDraftTopicsRequested(limit: kDefaultRowsPerPage)),
+        child: BlocListener<DraftTopicsBloc, DraftTopicsState>(
+          listenWhen: (previous, current) =>
+              previous.lastPendingDeletionId != current.lastPendingDeletionId ||
+              previous.publishedTopic != current.publishedTopic ||
+              previous.snackbarTopicTitle != current.snackbarTopicTitle,
+          listener: (context, state) {
+            if (state.publishedTopic != null) {
+              // When a topic is published, refresh the main topics list.
+              context.read<ContentManagementBloc>().add(
+                const LoadTopicsRequested(limit: kDefaultRowsPerPage),
+              );
+              // Clear the publishedTopic after it's been handled.
+              context.read<DraftTopicsBloc>().add(
+                const ClearPublishedTopic(),
+              );
+            }
+
+            // Show snackbar for pending deletions.
+            if (state.snackbarTopicTitle != null) {
+              final topicId = state.lastPendingDeletionId!;
+              final truncatedTitle = state.snackbarTopicTitle!.truncate(30);
+              ScaffoldMessenger.of(context)
+                ..hideCurrentSnackBar()
+                ..showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      l10n.topicDeleted(truncatedTitle),
+                    ),
+                    action: SnackBarAction(
+                      label: l10n.undo,
+                      onPressed: () {
+                        // Directly call undoDeletion on the service.
+                        pendingDeletionsService.undoDeletion(topicId);
+                      },
+                    ),
+                  ),
+                );
+            }
+          },
+          child: BlocBuilder<DraftTopicsBloc, DraftTopicsState>(
+            builder: (context, state) {
+              if (state.status == DraftTopicsStatus.loading &&
+                  state.topics.isEmpty) {
+                return LoadingStateWidget(
+                  icon: Icons.edit_note,
+                  headline: l10n.loadingDraftTopics,
+                  subheadline: l10n.pleaseWait,
+                );
+              }
+
+              if (state.status == DraftTopicsStatus.failure) {
+                return FailureStateWidget(
+                  exception: state.exception!,
+                  onRetry: () => context.read<DraftTopicsBloc>().add(
+                    const LoadDraftTopicsRequested(
+                      limit: kDefaultRowsPerPage,
+                    ),
+                  ),
+                );
+              }
+
+              if (state.topics.isEmpty) {
+                return Center(child: Text(l10n.noDraftTopicsFound));
+              }
+
+              return Column(
+                children: [
+                  if (state.status == DraftTopicsStatus.loading &&
+                      state.topics.isNotEmpty)
+                    const LinearProgressIndicator(),
+                  Expanded(
+                    child: PaginatedDataTable2(
+                      columns: [
+                        DataColumn2(
+                          label: Text(l10n.topicName),
+                          size: ColumnSize.L,
+                        ),
+                        DataColumn2(
+                          label: Text(l10n.lastUpdated),
+                          size: ColumnSize.M,
+                        ),
+                        DataColumn2(
+                          label: Text(l10n.actions),
+                          size: ColumnSize.S,
+                          fixedWidth: 120,
+                        ),
+                      ],
+                      source: _DraftTopicsDataSource(
+                        context: context,
+                        topics: state.topics,
+                        hasMore: state.hasMore,
+                        l10n: l10n,
+                      ),
+                      rowsPerPage: kDefaultRowsPerPage,
+                      availableRowsPerPage: const [kDefaultRowsPerPage],
+                      onPageChanged: (pageIndex) {
+                        final newOffset = pageIndex * kDefaultRowsPerPage;
+                        if (newOffset >= state.topics.length &&
+                            state.hasMore &&
+                            state.status != DraftTopicsStatus.loading) {
+                          context.read<DraftTopicsBloc>().add(
+                            LoadDraftTopicsRequested(
+                              startAfterId: state.cursor,
+                              limit: kDefaultRowsPerPage,
+                            ),
+                          );
+                        }
+                      },
+                      empty: Center(child: Text(l10n.noTopicsFound)),
+                      showCheckboxColumn: false,
+                      showFirstLastButtons: true,
+                      fit: FlexFit.tight,
+                      headingRowHeight: 56,
+                      dataRowHeight: 56,
+                      columnSpacing: AppSpacing.md,
+                      horizontalMargin: AppSpacing.md,
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
       ),
     );
   }
+}
+
+class _DraftTopicsDataSource extends DataTableSource {
+  _DraftTopicsDataSource({
+    required this.context,
+    required this.topics,
+    required this.hasMore,
+    required this.l10n,
+  });
+
+  final BuildContext context;
+  final List<Topic> topics;
+  final bool hasMore;
+  final AppLocalizations l10n;
+
+  @override
+  DataRow? getRow(int index) {
+    if (index >= topics.length) {
+      return null;
+    }
+    final topic = topics[index];
+    return DataRow2(
+      onSelectChanged: (selected) {
+        if (selected ?? false) {
+          context.goNamed(
+            Routes.editTopicName,
+            pathParameters: {'id': topic.id},
+          );
+        }
+      },
+      cells: [
+        DataCell(
+          Text(
+            topic.name,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        DataCell(
+          Text(
+            DateFormat('dd-MM-yyyy').format(topic.updatedAt.toLocal()),
+          ),
+        ),
+        DataCell(
+          Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.publish),
+                tooltip: l10n.publish,
+                onPressed: () {
+                  context.read<DraftTopicsBloc>().add(
+                    PublishDraftTopicRequested(topic.id),
+                  );
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.edit),
+                tooltip: l10n.editTopic,
+                onPressed: () {
+                  context.goNamed(
+                    Routes.editTopicName,
+                    pathParameters: {'id': topic.id},
+                  );
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete_forever),
+                tooltip: l10n.deleteForever,
+                onPressed: () {
+                  context.read<DraftTopicsBloc>().add(
+                    DeleteDraftTopicForeverRequested(topic.id),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  bool get isRowCountApproximate => hasMore;
+
+  @override
+  int get rowCount => topics.length;
+
+  @override
+  int get selectedRowCount => 0;
 }

--- a/lib/content_management/view/draft_topics_page.dart
+++ b/lib/content_management/view/draft_topics_page.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
+
+/// {@template draft_topics_page}
+/// A placeholder page for displaying draft topics.
+/// {@endtemplate}
+class DraftTopicsPage extends StatelessWidget {
+  /// {@macro draft_topics_page}
+  const DraftTopicsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.draftTopics),
+      ),
+      body: Center(
+        child: Text(l10n.draftTopics),
+      ),
+    );
+  }
+}

--- a/lib/content_management/view/edit_headline_page.dart
+++ b/lib/content_management/view/edit_headline_page.dart
@@ -66,58 +66,6 @@ class _EditHeadlineViewState extends State<_EditHeadlineView> {
     super.dispose();
   }
 
-  /// Shows a dialog to the user when the form is invalid, offering options
-  /// to complete the form or discard changes.
-  Future<void> _showInvalidFormDialog(BuildContext context) async {
-    final l10n = AppLocalizationsX(context).l10n;
-    final result = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.invalidFormTitle),
-        content: Text(l10n.invalidFormMessage),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(l10n.completeForm),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(l10n.discard),
-          ),
-        ],
-      ),
-    );
-
-    if (result ?? false) {
-      // If user chooses to discard, pop the page.
-      if (context.mounted) {
-        context.pop();
-      }
-    }
-  }
-
-  /// Shows a dialog to the user to choose between publishing or saving as draft.
-  Future<ContentStatus?> _showSaveOptionsDialog(BuildContext context) async {
-    final l10n = AppLocalizationsX(context).l10n;
-    return showDialog<ContentStatus>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.saveHeadlineTitle),
-        content: Text(l10n.saveHeadlineMessage),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(ContentStatus.draft),
-            child: Text(l10n.saveAsDraft),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(ContentStatus.active),
-            child: Text(l10n.publish),
-          ),
-        ],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizationsX(context).l10n;
@@ -137,27 +85,34 @@ class _EditHeadlineViewState extends State<_EditHeadlineView> {
                   ),
                 );
               }
+              // The save button is enabled only if the form is valid.
               return IconButton(
                 icon: const Icon(Icons.save),
                 tooltip: l10n.saveChanges,
-                onPressed: () async {
-                  if (state.isFormValid) {
-                    final selectedStatus = await _showSaveOptionsDialog(
-                      context,
-                    );
-                    if (selectedStatus == ContentStatus.active) {
-                      context.read<EditHeadlineBloc>().add(
-                        const EditHeadlinePublished(),
-                      );
-                    } else if (selectedStatus == ContentStatus.draft) {
-                      context.read<EditHeadlineBloc>().add(
-                        const EditHeadlineSavedAsDraft(),
-                      );
-                    }
-                  } else {
-                    await _showInvalidFormDialog(context);
-                  }
-                },
+                onPressed: state.isFormValid
+                    ? () async {
+                        // On edit page, directly save without a prompt.
+                        // The status (draft/active) is determined by the original headline
+                        // and is not changed by this save action unless a specific
+                        // "change status" UI element is introduced (out of scope).
+                        // For now, we assume the current status is maintained.
+                        final originalHeadline = await context
+                            .read<DataRepository<Headline>>()
+                            .read(id: state.headlineId);
+
+                        if (context.mounted) {
+                          if (originalHeadline.status == ContentStatus.active) {
+                            context.read<EditHeadlineBloc>().add(
+                              const EditHeadlinePublished(),
+                            );
+                          } else {
+                            context.read<EditHeadlineBloc>().add(
+                              const EditHeadlineSavedAsDraft(),
+                            );
+                          }
+                        }
+                      }
+                    : null, // Disable button if form is not valid
               );
             },
           ),

--- a/lib/content_management/view/edit_source_page.dart
+++ b/lib/content_management/view/edit_source_page.dart
@@ -60,6 +60,58 @@ class _EditSourceViewState extends State<_EditSourceView> {
     super.dispose();
   }
 
+  /// Shows a dialog to the user when the form is invalid, offering options
+  /// to complete the form or discard changes.
+  Future<void> _showInvalidFormDialog(BuildContext context) async {
+    final l10n = AppLocalizationsX(context).l10n;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.invalidFormTitle),
+        content: Text(l10n.invalidFormMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.completeForm),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.discard),
+          ),
+        ],
+      ),
+    );
+
+    if (result ?? false) {
+      // If user chooses to discard, pop the page.
+      if (context.mounted) {
+        context.pop();
+      }
+    }
+  }
+
+  /// Shows a dialog to the user to choose between publishing or saving as draft.
+  Future<ContentStatus?> _showSaveOptionsDialog(BuildContext context) async {
+    final l10n = AppLocalizationsX(context).l10n;
+    return showDialog<ContentStatus>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.saveSourceTitle),
+        content: Text(l10n.saveSourceMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(ContentStatus.draft),
+            child: Text(l10n.saveAsDraft),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(ContentStatus.active),
+            child: Text(l10n.publish),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizationsX(context).l10n;
@@ -82,11 +134,24 @@ class _EditSourceViewState extends State<_EditSourceView> {
               return IconButton(
                 icon: const Icon(Icons.save),
                 tooltip: l10n.saveChanges,
-                onPressed: state.isFormValid
-                    ? () => context.read<EditSourceBloc>().add(
-                        const EditSourceSubmitted(),
-                      )
-                    : null,
+                onPressed: () async {
+                  if (state.isFormValid) {
+                    final selectedStatus = await _showSaveOptionsDialog(
+                      context,
+                    );
+                    if (selectedStatus == ContentStatus.active) {
+                      context.read<EditSourceBloc>().add(
+                        const EditSourcePublished(),
+                      );
+                    } else if (selectedStatus == ContentStatus.draft) {
+                      context.read<EditSourceBloc>().add(
+                        const EditSourceSavedAsDraft(),
+                      );
+                    }
+                  } else {
+                    await _showInvalidFormDialog(context);
+                  }
+                },
               );
             },
           ),
@@ -252,21 +317,6 @@ class _EditSourceViewState extends State<_EditSourceView> {
                         SortOption('name', SortOrder.asc),
                       ],
                       limit: kDefaultRowsPerPage,
-                    ),
-                    const SizedBox(height: AppSpacing.lg),
-                    SearchableSelectionInput<ContentStatus>(
-                      label: l10n.status,
-                      selectedItem: state.contentStatus,
-                      staticItems: ContentStatus.values.toList(),
-                      itemBuilder: (context, status) =>
-                          Text(status.l10n(context)),
-                      itemToString: (status) => status.l10n(context),
-                      onChanged: (value) {
-                        if (value == null) return;
-                        context.read<EditSourceBloc>().add(
-                          EditSourceStatusChanged(value),
-                        );
-                      },
                     ),
                   ],
                 ),

--- a/lib/content_management/view/edit_topic_page.dart
+++ b/lib/content_management/view/edit_topic_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/bloc/content_management_bloc.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/bloc/edit_topic/edit_topic_bloc.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
-import 'package:flutter_news_app_web_dashboard_full_source_code/shared/shared.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ui_kit/ui_kit.dart';
 
@@ -61,6 +60,58 @@ class _EditTopicViewState extends State<_EditTopicView> {
     super.dispose();
   }
 
+  /// Shows a dialog to the user when the form is invalid, offering options
+  /// to complete the form or discard changes.
+  Future<void> _showInvalidFormDialog(BuildContext context) async {
+    final l10n = AppLocalizationsX(context).l10n;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.invalidFormTitle),
+        content: Text(l10n.invalidFormMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.completeForm),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.discard),
+          ),
+        ],
+      ),
+    );
+
+    if (result ?? false) {
+      // If user chooses to discard, pop the page.
+      if (context.mounted) {
+        context.pop();
+      }
+    }
+  }
+
+  /// Shows a dialog to the user to choose between publishing or saving as draft.
+  Future<ContentStatus?> _showSaveOptionsDialog(BuildContext context) async {
+    final l10n = AppLocalizationsX(context).l10n;
+    return showDialog<ContentStatus>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.saveTopicTitle),
+        content: Text(l10n.saveTopicMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(ContentStatus.draft),
+            child: Text(l10n.saveAsDraft),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(ContentStatus.active),
+            child: Text(l10n.publish),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizationsX(context).l10n;
@@ -83,11 +134,24 @@ class _EditTopicViewState extends State<_EditTopicView> {
               return IconButton(
                 icon: const Icon(Icons.save),
                 tooltip: l10n.saveChanges,
-                onPressed: state.isFormValid
-                    ? () => context.read<EditTopicBloc>().add(
-                        const EditTopicSubmitted(),
-                      )
-                    : null,
+                onPressed: () async {
+                  if (state.isFormValid) {
+                    final selectedStatus = await _showSaveOptionsDialog(
+                      context,
+                    );
+                    if (selectedStatus == ContentStatus.active) {
+                      context.read<EditTopicBloc>().add(
+                        const EditTopicPublished(),
+                      );
+                    } else if (selectedStatus == ContentStatus.draft) {
+                      context.read<EditTopicBloc>().add(
+                        const EditTopicSavedAsDraft(),
+                      );
+                    }
+                  } else {
+                    await _showInvalidFormDialog(context);
+                  }
+                },
               );
             },
           ),
@@ -183,21 +247,6 @@ class _EditTopicViewState extends State<_EditTopicView> {
                       onChanged: (value) => context.read<EditTopicBloc>().add(
                         EditTopicIconUrlChanged(value),
                       ),
-                    ),
-                    const SizedBox(height: AppSpacing.lg),
-                    SearchableSelectionInput<ContentStatus>(
-                      label: l10n.status,
-                      selectedItem: state.contentStatus,
-                      staticItems: ContentStatus.values.toList(),
-                      itemBuilder: (context, status) =>
-                          Text(status.l10n(context)),
-                      itemToString: (status) => status.l10n(context),
-                      onChanged: (value) {
-                        if (value == null) return;
-                        context.read<EditTopicBloc>().add(
-                          EditTopicStatusChanged(value),
-                        );
-                      },
                     ),
                   ],
                 ),

--- a/lib/content_management/view/edit_topic_page.dart
+++ b/lib/content_management/view/edit_topic_page.dart
@@ -60,58 +60,6 @@ class _EditTopicViewState extends State<_EditTopicView> {
     super.dispose();
   }
 
-  /// Shows a dialog to the user when the form is invalid, offering options
-  /// to complete the form or discard changes.
-  Future<void> _showInvalidFormDialog(BuildContext context) async {
-    final l10n = AppLocalizationsX(context).l10n;
-    final result = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.invalidFormTitle),
-        content: Text(l10n.invalidFormMessage),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(l10n.completeForm),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(l10n.discard),
-          ),
-        ],
-      ),
-    );
-
-    if (result ?? false) {
-      // If user chooses to discard, pop the page.
-      if (context.mounted) {
-        context.pop();
-      }
-    }
-  }
-
-  /// Shows a dialog to the user to choose between publishing or saving as draft.
-  Future<ContentStatus?> _showSaveOptionsDialog(BuildContext context) async {
-    final l10n = AppLocalizationsX(context).l10n;
-    return showDialog<ContentStatus>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.saveTopicTitle),
-        content: Text(l10n.saveTopicMessage),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(ContentStatus.draft),
-            child: Text(l10n.saveAsDraft),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(ContentStatus.active),
-            child: Text(l10n.publish),
-          ),
-        ],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizationsX(context).l10n;
@@ -131,27 +79,34 @@ class _EditTopicViewState extends State<_EditTopicView> {
                   ),
                 );
               }
+              // The save button is enabled only if the form is valid.
               return IconButton(
                 icon: const Icon(Icons.save),
                 tooltip: l10n.saveChanges,
-                onPressed: () async {
-                  if (state.isFormValid) {
-                    final selectedStatus = await _showSaveOptionsDialog(
-                      context,
-                    );
-                    if (selectedStatus == ContentStatus.active) {
-                      context.read<EditTopicBloc>().add(
-                        const EditTopicPublished(),
-                      );
-                    } else if (selectedStatus == ContentStatus.draft) {
-                      context.read<EditTopicBloc>().add(
-                        const EditTopicSavedAsDraft(),
-                      );
-                    }
-                  } else {
-                    await _showInvalidFormDialog(context);
-                  }
-                },
+                onPressed: state.isFormValid
+                    ? () async {
+                        // On edit page, directly save without a prompt.
+                        // The status (draft/active) is determined by the original topic
+                        // and is not changed by this save action unless a specific
+                        // "change status" UI element is introduced (out of scope).
+                        // For now, we assume the current status is maintained.
+                        final originalTopic = await context
+                            .read<DataRepository<Topic>>()
+                            .read(id: state.topicId);
+
+                        if (context.mounted) {
+                          if (originalTopic.status == ContentStatus.active) {
+                            context.read<EditTopicBloc>().add(
+                              const EditTopicPublished(),
+                            );
+                          } else {
+                            context.read<EditTopicBloc>().add(
+                              const EditTopicSavedAsDraft(),
+                            );
+                          }
+                        }
+                      }
+                    : null, // Disable button if form is not valid
               );
             },
           ),

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2539,6 +2539,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Do you want to publish this source or save it as a draft?'**
   String get saveSourceMessage;
+
+  /// Message displayed when draft topics are being loaded.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading Draft Topics...'**
+  String get loadingDraftTopics;
+
+  /// Message displayed when no draft topics are available.
+  ///
+  /// In en, this message translates to:
+  /// **'No draft topics found.'**
+  String get noDraftTopicsFound;
+
+  /// Snackbar message when a topic is deleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Topic \"{topicTitle}\" deleted.'**
+  String topicDeleted(String topicTitle);
+
+  /// Message displayed when draft sources are being loaded.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading Draft Sources...'**
+  String get loadingDraftSources;
+
+  /// Message displayed when no draft sources are available.
+  ///
+  /// In en, this message translates to:
+  /// **'No draft sources found.'**
+  String get noDraftSourcesFound;
+
+  /// Snackbar message when a source is deleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Source \"{sourceName}\" deleted.'**
+  String sourceDeleted(String sourceName);
+
+  /// Tooltip for the publish topic button.
+  ///
+  /// In en, this message translates to:
+  /// **'Publish Topic'**
+  String get publishTopic;
+
+  /// Tooltip for the publish source button.
+  ///
+  /// In en, this message translates to:
+  /// **'Publish Source'**
+  String get publishSource;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2503,6 +2503,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Draft Sources'**
   String get draftSources;
+
+  /// Title for the dialog asking how to save a headline.
+  ///
+  /// In en, this message translates to:
+  /// **'Save Headline'**
+  String get saveHeadlineTitle;
+
+  /// Message for the dialog asking how to save a headline.
+  ///
+  /// In en, this message translates to:
+  /// **'Do you want to publish this headline or save it as a draft?'**
+  String get saveHeadlineMessage;
+
+  /// Title for the dialog asking how to save a topic.
+  ///
+  /// In en, this message translates to:
+  /// **'Save Topic'**
+  String get saveTopicTitle;
+
+  /// Message for the dialog asking how to save a topic.
+  ///
+  /// In en, this message translates to:
+  /// **'Do you want to publish this topic or save it as a draft?'**
+  String get saveTopicMessage;
+
+  /// Title for the dialog asking how to save a source.
+  ///
+  /// In en, this message translates to:
+  /// **'Save Source'**
+  String get saveSourceTitle;
+
+  /// Message for the dialog asking how to save a source.
+  ///
+  /// In en, this message translates to:
+  /// **'Do you want to publish this source or save it as a draft?'**
+  String get saveSourceMessage;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1354,4 +1354,32 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get saveSourceMessage => 'هل تريد نشر هذا المصدر أم حفظه كمسودة؟';
+
+  @override
+  String get loadingDraftTopics => 'جاري تحميل مسودات المواضيع...';
+
+  @override
+  String get noDraftTopicsFound => 'لم يتم العثور على مسودات مواضيع.';
+
+  @override
+  String topicDeleted(String topicTitle) {
+    return 'تم حذف الموضوع \"$topicTitle\".';
+  }
+
+  @override
+  String get loadingDraftSources => 'جاري تحميل مسودات المصادر...';
+
+  @override
+  String get noDraftSourcesFound => 'لم يتم العثور على مسودات مصادر.';
+
+  @override
+  String sourceDeleted(String sourceName) {
+    return 'تم حذف المصدر \"$sourceName\".';
+  }
+
+  @override
+  String get publishTopic => 'نشر الموضوع';
+
+  @override
+  String get publishSource => 'نشر المصدر';
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1336,4 +1336,22 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get draftSources => 'مسودات المصادر';
+
+  @override
+  String get saveHeadlineTitle => 'حفظ العنوان';
+
+  @override
+  String get saveHeadlineMessage => 'هل تريد نشر هذا العنوان أم حفظه كمسودة؟';
+
+  @override
+  String get saveTopicTitle => 'حفظ الموضوع';
+
+  @override
+  String get saveTopicMessage => 'هل تريد نشر هذا الموضوع أم حفظه كمسودة؟';
+
+  @override
+  String get saveSourceTitle => 'حفظ المصدر';
+
+  @override
+  String get saveSourceMessage => 'هل تريد نشر هذا المصدر أم حفظه كمسودة؟';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1338,4 +1338,25 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get draftSources => 'Draft Sources';
+
+  @override
+  String get saveHeadlineTitle => 'Save Headline';
+
+  @override
+  String get saveHeadlineMessage =>
+      'Do you want to publish this headline or save it as a draft?';
+
+  @override
+  String get saveTopicTitle => 'Save Topic';
+
+  @override
+  String get saveTopicMessage =>
+      'Do you want to publish this topic or save it as a draft?';
+
+  @override
+  String get saveSourceTitle => 'Save Source';
+
+  @override
+  String get saveSourceMessage =>
+      'Do you want to publish this source or save it as a draft?';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1359,4 +1359,32 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get saveSourceMessage =>
       'Do you want to publish this source or save it as a draft?';
+
+  @override
+  String get loadingDraftTopics => 'Loading Draft Topics...';
+
+  @override
+  String get noDraftTopicsFound => 'No draft topics found.';
+
+  @override
+  String topicDeleted(String topicTitle) {
+    return 'Topic \"$topicTitle\" deleted.';
+  }
+
+  @override
+  String get loadingDraftSources => 'Loading Draft Sources...';
+
+  @override
+  String get noDraftSourcesFound => 'No draft sources found.';
+
+  @override
+  String sourceDeleted(String sourceName) {
+    return 'Source \"$sourceName\" deleted.';
+  }
+
+  @override
+  String get publishTopic => 'Publish Topic';
+
+  @override
+  String get publishSource => 'Publish Source';
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1677,5 +1677,29 @@
   "draftSources": "مسودات المصادر",
   "@draftSources": {
     "description": "Title for the Draft Sources page"
+  },
+  "saveHeadlineTitle": "حفظ العنوان",
+  "@saveHeadlineTitle": {
+    "description": "عنوان مربع الحوار الذي يسأل عن كيفية حفظ العنوان."
+  },
+  "saveHeadlineMessage": "هل تريد نشر هذا العنوان أم حفظه كمسودة؟",
+  "@saveHeadlineMessage": {
+    "description": "رسالة مربع الحوار الذي يسأل عن كيفية حفظ العنوان."
+  },
+  "saveTopicTitle": "حفظ الموضوع",
+  "@saveTopicTitle": {
+    "description": "عنوان مربع الحوار الذي يسأل عن كيفية حفظ الموضوع."
+  },
+  "saveTopicMessage": "هل تريد نشر هذا الموضوع أم حفظه كمسودة؟",
+  "@saveTopicMessage": {
+    "description": "رسالة مربع الحوار الذي يسأل عن كيفية حفظ الموضوع."
+  },
+  "saveSourceTitle": "حفظ المصدر",
+  "@saveSourceTitle": {
+    "description": "عنوان مربع الحوار الذي يسأل عن كيفية حفظ المصدر."
+  },
+  "saveSourceMessage": "هل تريد نشر هذا المصدر أم حفظه كمسودة؟",
+  "@saveSourceMessage": {
+    "description": "رسالة مربع الحوار الذي يسأل عن كيفية حفظ المصدر."
   }
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1701,5 +1701,49 @@
   "saveSourceMessage": "هل تريد نشر هذا المصدر أم حفظه كمسودة؟",
   "@saveSourceMessage": {
     "description": "رسالة مربع الحوار الذي يسأل عن كيفية حفظ المصدر."
+  },
+  "loadingDraftTopics": "جاري تحميل مسودات المواضيع...",
+  "@loadingDraftTopics": {
+    "description": "رسالة تعرض عند تحميل مسودات المواضيع."
+  },
+  "noDraftTopicsFound": "لم يتم العثور على مسودات مواضيع.",
+  "@noDraftTopicsFound": {
+    "description": "رسالة تعرض عندما لا تتوفر مسودات مواضيع."
+  },
+  "topicDeleted": "تم حذف الموضوع \"{topicTitle}\".",
+  "@topicDeleted": {
+    "description": "رسالة شريط التنبيه عند حذف موضوع.",
+    "placeholders": {
+      "topicTitle": {
+        "type": "String",
+        "example": "التكنولوجيا"
+      }
+    }
+  },
+  "loadingDraftSources": "جاري تحميل مسودات المصادر...",
+  "@loadingDraftSources": {
+    "description": "رسالة تعرض عند تحميل مسودات المصادر."
+  },
+  "noDraftSourcesFound": "لم يتم العثور على مسودات مصادر.",
+  "@noDraftSourcesFound": {
+    "description": "رسالة تعرض عندما لا تتوفر مسودات مصادر."
+  },
+  "sourceDeleted": "تم حذف المصدر \"{sourceName}\".",
+  "@sourceDeleted": {
+    "description": "رسالة شريط التنبيه عند حذف مصدر.",
+    "placeholders": {
+      "sourceName": {
+        "type": "String",
+        "example": "بي بي سي نيوز"
+      }
+    }
+  },
+  "publishTopic": "نشر الموضوع",
+  "@publishTopic": {
+    "description": "تلميح زر نشر الموضوع."
+  },
+  "publishSource": "نشر المصدر",
+  "@publishSource": {
+    "description": "تلميح زر نشر المصدر."
   }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1697,5 +1697,49 @@
   "saveSourceMessage": "Do you want to publish this source or save it as a draft?",
   "@saveSourceMessage": {
     "description": "Message for the dialog asking how to save a source."
+  },
+  "loadingDraftTopics": "Loading Draft Topics...",
+  "@loadingDraftTopics": {
+    "description": "Message displayed when draft topics are being loaded."
+  },
+  "noDraftTopicsFound": "No draft topics found.",
+  "@noDraftTopicsFound": {
+    "description": "Message displayed when no draft topics are available."
+  },
+  "topicDeleted": "Topic \"{topicTitle}\" deleted.",
+  "@topicDeleted": {
+    "description": "Snackbar message when a topic is deleted.",
+    "placeholders": {
+      "topicTitle": {
+        "type": "String",
+        "example": "Technology"
+      }
+    }
+  },
+  "loadingDraftSources": "Loading Draft Sources...",
+  "@loadingDraftSources": {
+    "description": "Message displayed when draft sources are being loaded."
+  },
+  "noDraftSourcesFound": "No draft sources found.",
+  "@noDraftSourcesFound": {
+    "description": "Message displayed when no draft sources are available."
+  },
+  "sourceDeleted": "Source \"{sourceName}\" deleted.",
+  "@sourceDeleted": {
+    "description": "Snackbar message when a source is deleted.",
+    "placeholders": {
+      "sourceName": {
+        "type": "String",
+        "example": "BBC News"
+      }
+    }
+  },
+  "publishTopic": "Publish Topic",
+  "@publishTopic": {
+    "description": "Tooltip for the publish topic button."
+  },
+  "publishSource": "Publish Source",
+  "@publishSource": {
+    "description": "Tooltip for the publish source button."
   }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1673,5 +1673,29 @@
   "draftSources": "Draft Sources",
   "@draftSources": {
     "description": "Title for the Draft Sources page"
+  },
+  "saveHeadlineTitle": "Save Headline",
+  "@saveHeadlineTitle": {
+    "description": "Title for the dialog asking how to save a headline."
+  },
+  "saveHeadlineMessage": "Do you want to publish this headline or save it as a draft?",
+  "@saveHeadlineMessage": {
+    "description": "Message for the dialog asking how to save a headline."
+  },
+  "saveTopicTitle": "Save Topic",
+  "@saveTopicTitle": {
+    "description": "Title for the dialog asking how to save a topic."
+  },
+  "saveTopicMessage": "Do you want to publish this topic or save it as a draft?",
+  "@saveTopicMessage": {
+    "description": "Message for the dialog asking how to save a topic."
+  },
+  "saveSourceTitle": "Save Source",
+  "@saveSourceTitle": {
+    "description": "Title for the dialog asking how to save a source."
+  },
+  "saveSourceMessage": "Do you want to publish this source or save it as a draft?",
+  "@saveSourceMessage": {
+    "description": "Message for the dialog asking how to save a source."
   }
 }

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -18,6 +18,8 @@ import 'package:flutter_news_app_web_dashboard_full_source_code/content_manageme
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/create_source_page.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/create_topic_page.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/draft_headlines_page.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/draft_sources_page.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/draft_topics_page.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/edit_headline_page.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/edit_source_page.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/content_management/view/edit_topic_page.dart';
@@ -231,6 +233,16 @@ GoRouter createRouter({
                     path: Routes.draftHeadlines,
                     name: Routes.draftHeadlinesName,
                     builder: (context, state) => const DraftHeadlinesPage(),
+                  ),
+                  GoRoute(
+                    path: Routes.draftSources,
+                    name: Routes.draftSourcesName,
+                    builder: (context, state) => const DraftSourcesPage(),
+                  ),
+                  GoRoute(
+                    path: Routes.draftTopics,
+                    name: Routes.draftTopicsName,
+                    builder: (context, state) => const DraftTopicsPage(),
                   ),
                   // Moved searchableSelection as a sub-route of content-management
                   GoRoute(

--- a/lib/router/routes.dart
+++ b/lib/router/routes.dart
@@ -68,6 +68,18 @@ abstract final class Routes {
   /// The name for the draft headlines page route.
   static const String draftHeadlinesName = 'draftHeadlines';
 
+  /// The path for the draft topics page.
+  static const String draftTopics = 'draft-topics';
+
+  /// The name for the draft topics page route.
+  static const String draftTopicsName = 'draftTopics';
+
+  /// The path for the draft sources page.
+  static const String draftSources = 'draft-sources';
+
+  /// The name for the draft sources page route.
+  static const String draftSourcesName = 'draftSources';
+
   /// The path for creating a new headline.
   static const String createHeadline = 'create-headline';
 

--- a/lib/shared/widgets/searchable_selection_input.dart
+++ b/lib/shared/widgets/searchable_selection_input.dart
@@ -136,6 +136,7 @@ class _SearchableSelectionInputState<T>
         filterBuilder: widget.filterBuilder,
         sortOptions: widget.sortOptions,
         limit: widget.limit,
+        // Pass the flag to the selection page arguments.
         includeInactiveSelectedItem: widget.includeInactiveSelectedItem,
       );
     } else {
@@ -146,6 +147,7 @@ class _SearchableSelectionInputState<T>
         itemToString: (item) => widget.itemToString(item as T),
         initialSelectedItem: widget.selectedItem,
         staticItems: widget.staticItems! as List<Object>,
+        // Pass the flag to the selection page arguments.
         includeInactiveSelectedItem: widget.includeInactiveSelectedItem,
       );
     }

--- a/lib/shared/widgets/selection_page/bloc/searchable_selection_bloc.dart
+++ b/lib/shared/widgets/selection_page/bloc/searchable_selection_bloc.dart
@@ -83,12 +83,20 @@ class SearchableSelectionBloc
         hasMore = false;
       } else if (_arguments.repository != null) {
         // Handle repository-fetched items
-        final filter = _arguments.filterBuilder!(
+        final baseFilter = _arguments.filterBuilder!(
           state.searchTerm.isEmpty ? null : state.searchTerm,
         );
 
+        // Apply default filter for active items unless includeInactiveSelectedItem is true
+        final finalFilter = _arguments.includeInactiveSelectedItem
+            ? baseFilter
+            : {
+                ...baseFilter,
+                'status': ContentStatus.active.name,
+              };
+
         final response = await (_arguments.repository!).readAll(
-          filter: filter,
+          filter: finalFilter,
           sort: _arguments.sortOptions,
           pagination: PaginationOptions(limit: _arguments.limit),
         );
@@ -174,11 +182,20 @@ class SearchableSelectionBloc
 
     emit(state.copyWith(status: SearchableSelectionStatus.loading));
     try {
-      final filter = _arguments.filterBuilder!(
+      final baseFilter = _arguments.filterBuilder!(
         state.searchTerm.isEmpty ? null : state.searchTerm,
       );
+
+      // Apply default filter for active items unless includeInactiveSelectedItem is true
+      final finalFilter = _arguments.includeInactiveSelectedItem
+          ? baseFilter
+          : {
+              ...baseFilter,
+              'status': ContentStatus.active.name,
+            };
+
       final response = await (_arguments.repository!).readAll(
-        filter: filter,
+        filter: finalFilter,
         sort: _arguments.sortOptions,
         pagination: PaginationOptions(
           cursor: state.cursor,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

This pull request introduces a comprehensive drafting system across headlines, topics, and sources, significantly enhancing content management flexibility. Users can now save content as drafts, manage them in dedicated draft sections, and then publish or permanently delete them. The changes involve substantial refactoring of content creation and editing BLoCs, the addition of new UI pages for draft management, seamless integration with a pending deletions service for a better user experience, and updates to localization and a reusable selection input widget.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore
