### PR TITLE
Feat/fix local ads archiving undo

### DIFF
--- a/lib/app_configuration/widgets/article_ad_settings_form.dart
+++ b/lib/app_configuration/widgets/article_ad_settings_form.dart
@@ -2,9 +2,9 @@ import 'package:core/core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/app_localizations.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
+import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/app_user_role_l10n.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/banner_ad_shape_l10n.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/in_article_ad_slot_type_l10n.dart';
-import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/app_user_role_l10n.dart';
 import 'package:ui_kit/ui_kit.dart';
 
 /// {@template article_ad_settings_form}

--- a/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_bloc.dart
+++ b/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_bloc.dart
@@ -5,7 +5,6 @@ import 'package:core/core.dart';
 import 'package:data_repository/data_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/shared/services/pending_deletions_service.dart';
-import 'package:ui_kit/ui_kit.dart';
 
 part 'archive_local_ads_event.dart';
 part 'archive_local_ads_state.dart';

--- a/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_bloc.dart
+++ b/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_bloc.dart
@@ -313,7 +313,6 @@ class ArchiveLocalAdsBloc
         id: event.id,
         item: updatedAd,
       );
-      emit(state.copyWith(restoredLocalAd: updatedAd));
     } on HttpException catch (e) {
       // Revert UI on failure
       switch (event.adType) {
@@ -519,7 +518,6 @@ class ArchiveLocalAdsBloc
                     ? null
                     : state.lastPendingDeletionId,
                 snackbarLocalAdTitle: null,
-                restoredLocalAd: item,
               ),
             );
           case 'banner':
@@ -532,7 +530,6 @@ class ArchiveLocalAdsBloc
                     ? null
                     : state.lastPendingDeletionId,
                 snackbarLocalAdTitle: null,
-                restoredLocalAd: item,
               ),
             );
           case 'interstitial':
@@ -546,7 +543,6 @@ class ArchiveLocalAdsBloc
                     ? null
                     : state.lastPendingDeletionId,
                 snackbarLocalAdTitle: null,
-                restoredLocalAd: item,
               ),
             );
           case 'video':
@@ -559,7 +555,6 @@ class ArchiveLocalAdsBloc
                     ? null
                     : state.lastPendingDeletionId,
                 snackbarLocalAdTitle: null,
-                restoredLocalAd: item,
               ),
             );
         }

--- a/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_bloc.dart
+++ b/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_bloc.dart
@@ -22,9 +22,9 @@ class ArchiveLocalAdsBloc
   ArchiveLocalAdsBloc({
     required DataRepository<LocalAd> localAdsRepository,
     required PendingDeletionsService pendingDeletionsService,
-  })  : _localAdsRepository = localAdsRepository,
-        _pendingDeletionsService = pendingDeletionsService,
-        super(const ArchiveLocalAdsState()) {
+  }) : _localAdsRepository = localAdsRepository,
+       _pendingDeletionsService = pendingDeletionsService,
+       super(const ArchiveLocalAdsState()) {
     on<LoadArchivedLocalAdsRequested>(_onLoadArchivedLocalAdsRequested);
     on<RestoreLocalAdRequested>(_onRestoreLocalAdRequested);
     on<DeleteLocalAdForeverRequested>(_onDeleteLocalAdForeverRequested);
@@ -46,7 +46,7 @@ class ArchiveLocalAdsBloc
 
   /// Subscription to deletion events from the PendingDeletionsService.
   late final StreamSubscription<DeletionEvent<dynamic>>
-      _deletionEventSubscription;
+  _deletionEventSubscription;
 
   @override
   Future<void> close() {
@@ -93,7 +93,9 @@ class ArchiveLocalAdsBloc
 
       switch (event.adType) {
         case AdType.native:
-          final previousAds = isPaginating ? state.nativeAds : <LocalNativeAd>[];
+          final previousAds = isPaginating
+              ? state.nativeAds
+              : <LocalNativeAd>[];
           emit(
             state.copyWith(
               nativeAdsStatus: ArchiveLocalAdsStatus.success,
@@ -106,7 +108,9 @@ class ArchiveLocalAdsBloc
             ),
           );
         case AdType.banner:
-          final previousAds = isPaginating ? state.bannerAds : <LocalBannerAd>[];
+          final previousAds = isPaginating
+              ? state.bannerAds
+              : <LocalBannerAd>[];
           emit(
             state.copyWith(
               bannerAdsStatus: ArchiveLocalAdsStatus.success,

--- a/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_event.dart
+++ b/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_event.dart
@@ -73,17 +73,12 @@ final class UndoDeleteLocalAdRequested extends ArchiveLocalAdsEvent {
   const UndoDeleteLocalAdRequested();
 }
 
-/// Internal event to confirm the permanent deletion of a local ad after a delay.
-final class _ConfirmDeleteLocalAdRequested extends ArchiveLocalAdsEvent {
-  /// {@macro _confirm_delete_local_ad_requested}
-  const _ConfirmDeleteLocalAdRequested(this.id, this.adType);
+/// Event to handle updates from the pending deletions service.
+final class _DeletionServiceStatusChanged extends ArchiveLocalAdsEvent {
+  const _DeletionServiceStatusChanged(this.event);
 
-  /// The ID of the local ad to confirm deletion for.
-  final String id;
-
-  /// The type of the local ad to confirm deletion for.
-  final AdType adType;
+  final DeletionEvent<dynamic> event;
 
   @override
-  List<Object?> get props => [id, adType];
+  List<Object?> get props => [event];
 }

--- a/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
+++ b/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
@@ -139,7 +139,8 @@ class ArchiveLocalAdsState extends Equatable {
       videoAdsCursor: videoAdsCursor ?? this.videoAdsCursor,
       videoAdsHasMore: videoAdsHasMore ?? this.videoAdsHasMore,
       exception: exception,
-      lastPendingDeletionId: lastPendingDeletionId ?? this.lastPendingDeletionId,
+      lastPendingDeletionId:
+          lastPendingDeletionId ?? this.lastPendingDeletionId,
       snackbarLocalAdTitle: snackbarLocalAdTitle,
     );
   }

--- a/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
+++ b/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
@@ -143,9 +143,8 @@ class ArchiveLocalAdsState extends Equatable {
       videoAds: videoAds ?? this.videoAds,
       videoAdsCursor: videoAdsCursor ?? this.videoAdsCursor,
       videoAdsHasMore: videoAdsHasMore ?? this.videoAdsHasMore,
-      exception: exception, // Explicitly set to null if not provided
-      restoredLocalAd:
-          restoredLocalAd, // Explicitly set to null if not provided
+      exception: exception,
+      restoredLocalAd: restoredLocalAd,
       lastPendingDeletionId: lastPendingDeletionId,
       snackbarLocalAdTitle: snackbarLocalAdTitle,
     );

--- a/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
+++ b/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
@@ -29,8 +29,9 @@ class ArchiveLocalAdsState extends Equatable {
     this.videoAdsCursor,
     this.videoAdsHasMore = false,
     this.exception,
-    this.lastDeletedLocalAd,
     this.restoredLocalAd,
+    this.lastPendingDeletionId,
+    this.snackbarLocalAdTitle,
   });
 
   final ArchiveLocalAdsStatus status;
@@ -86,11 +87,17 @@ class ArchiveLocalAdsState extends Equatable {
   /// The error describing an operation failure, if any.
   final HttpException? exception;
 
-  /// The last deleted local ad, used for undo functionality.
-  final LocalAd? lastDeletedLocalAd;
-
   /// The last restored local ad, used for triggering UI updates.
   final LocalAd? restoredLocalAd;
+
+  /// The ID of the local ad that was most recently added to pending deletions.
+  /// Used to trigger the snackbar display.
+  final String? lastPendingDeletionId;
+
+  /// The title of the local ad for which the snackbar should be displayed.
+  /// This is set when a deletion is requested and cleared when the snackbar
+  /// is no longer needed.
+  final String? snackbarLocalAdTitle;
 
   ArchiveLocalAdsState copyWith({
     ArchiveLocalAdsStatus? status,
@@ -111,10 +118,9 @@ class ArchiveLocalAdsState extends Equatable {
     String? videoAdsCursor,
     bool? videoAdsHasMore,
     HttpException? exception,
-    LocalAd? lastDeletedLocalAd,
     LocalAd? restoredLocalAd,
-    bool clearLastDeletedLocalAd = false,
-    bool clearRestoredLocalAd = false,
+    String? lastPendingDeletionId,
+    String? snackbarLocalAdTitle,
   }) {
     return ArchiveLocalAdsState(
       status: status ?? this.status,
@@ -137,13 +143,11 @@ class ArchiveLocalAdsState extends Equatable {
       videoAds: videoAds ?? this.videoAds,
       videoAdsCursor: videoAdsCursor ?? this.videoAdsCursor,
       videoAdsHasMore: videoAdsHasMore ?? this.videoAdsHasMore,
-      exception: exception ?? this.exception,
-      lastDeletedLocalAd: clearLastDeletedLocalAd
-          ? null
-          : lastDeletedLocalAd ?? this.lastDeletedLocalAd,
-      restoredLocalAd: clearRestoredLocalAd
-          ? null
-          : restoredLocalAd ?? this.restoredLocalAd,
+      exception: exception, // Explicitly set to null if not provided
+      restoredLocalAd:
+          restoredLocalAd, // Explicitly set to null if not provided
+      lastPendingDeletionId: lastPendingDeletionId,
+      snackbarLocalAdTitle: snackbarLocalAdTitle,
     );
   }
 
@@ -167,7 +171,8 @@ class ArchiveLocalAdsState extends Equatable {
     videoAdsCursor,
     videoAdsHasMore,
     exception,
-    lastDeletedLocalAd,
     restoredLocalAd,
+    lastPendingDeletionId,
+    snackbarLocalAdTitle,
   ];
 }

--- a/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
+++ b/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
@@ -143,10 +143,10 @@ class ArchiveLocalAdsState extends Equatable {
       videoAds: videoAds ?? this.videoAds,
       videoAdsCursor: videoAdsCursor ?? this.videoAdsCursor,
       videoAdsHasMore: videoAdsHasMore ?? this.videoAdsHasMore,
-      exception: exception,
-      restoredLocalAd: restoredLocalAd,
-      lastPendingDeletionId: lastPendingDeletionId,
-      snackbarLocalAdTitle: snackbarLocalAdTitle,
+      exception: exception ?? this.exception,
+      restoredLocalAd: restoredLocalAd ?? this.restoredLocalAd,
+      lastPendingDeletionId: lastPendingDeletionId ?? this.lastPendingDeletionId,
+      snackbarLocalAdTitle: snackbarLocalAdTitle ?? this.snackbarLocalAdTitle,
     );
   }
 

--- a/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
+++ b/lib/local_ads_management/bloc/archive_local_ads/archive_local_ads_state.dart
@@ -29,7 +29,6 @@ class ArchiveLocalAdsState extends Equatable {
     this.videoAdsCursor,
     this.videoAdsHasMore = false,
     this.exception,
-    this.restoredLocalAd,
     this.lastPendingDeletionId,
     this.snackbarLocalAdTitle,
   });
@@ -87,9 +86,6 @@ class ArchiveLocalAdsState extends Equatable {
   /// The error describing an operation failure, if any.
   final HttpException? exception;
 
-  /// The last restored local ad, used for triggering UI updates.
-  final LocalAd? restoredLocalAd;
-
   /// The ID of the local ad that was most recently added to pending deletions.
   /// Used to trigger the snackbar display.
   final String? lastPendingDeletionId;
@@ -118,7 +114,6 @@ class ArchiveLocalAdsState extends Equatable {
     String? videoAdsCursor,
     bool? videoAdsHasMore,
     HttpException? exception,
-    LocalAd? restoredLocalAd,
     String? lastPendingDeletionId,
     String? snackbarLocalAdTitle,
   }) {
@@ -143,10 +138,9 @@ class ArchiveLocalAdsState extends Equatable {
       videoAds: videoAds ?? this.videoAds,
       videoAdsCursor: videoAdsCursor ?? this.videoAdsCursor,
       videoAdsHasMore: videoAdsHasMore ?? this.videoAdsHasMore,
-      exception: exception ?? this.exception,
-      restoredLocalAd: restoredLocalAd ?? this.restoredLocalAd,
+      exception: exception,
       lastPendingDeletionId: lastPendingDeletionId ?? this.lastPendingDeletionId,
-      snackbarLocalAdTitle: snackbarLocalAdTitle ?? this.snackbarLocalAdTitle,
+      snackbarLocalAdTitle: snackbarLocalAdTitle,
     );
   }
 
@@ -170,7 +164,6 @@ class ArchiveLocalAdsState extends Equatable {
     videoAdsCursor,
     videoAdsHasMore,
     exception,
-    restoredLocalAd,
     lastPendingDeletionId,
     snackbarLocalAdTitle,
   ];

--- a/lib/local_ads_management/view/archived_local_ads_page.dart
+++ b/lib/local_ads_management/view/archived_local_ads_page.dart
@@ -6,11 +6,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/app_localizations.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/l10n/l10n.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/local_ads_management/bloc/archive_local_ads/archive_local_ads_bloc.dart';
-import 'package:flutter_news_app_web_dashboard_full_source_code/local_ads_management/bloc/local_ads_management_bloc.dart'
-    hide
-        DeleteLocalAdForeverRequested,
-        RestoreLocalAdRequested,
-        UndoDeleteLocalAdRequested;
 import 'package:flutter_news_app_web_dashboard_full_source_code/shared/extensions/extensions.dart';
 import 'package:flutter_news_app_web_dashboard_full_source_code/shared/services/pending_deletions_service.dart';
 import 'package:intl/intl.dart';

--- a/lib/local_ads_management/view/archived_local_ads_page.dart
+++ b/lib/local_ads_management/view/archived_local_ads_page.dart
@@ -79,7 +79,6 @@ class _ArchivedLocalAdsViewState extends State<_ArchivedLocalAdsView>
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizationsX(context).l10n;
-    final pendingDeletionsService = context.read<PendingDeletionsService>();
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.archivedLocalAdsTitle),
@@ -110,7 +109,9 @@ class _ArchivedLocalAdsViewState extends State<_ArchivedLocalAdsView>
                   action: SnackBarAction(
                     label: l10n.undo,
                     onPressed: () {
-                      pendingDeletionsService.undoDeletion(adId);
+                      context.read<ArchiveLocalAdsBloc>().add(
+                        const UndoDeleteLocalAdRequested(),
+                      );
                     },
                   ),
                 ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

This pull request implements a significant refactoring of the local ads archiving feature, specifically enhancing the undo deletion mechanism. By introducing a dedicated PendingDeletionsService, the logic for managing temporary deletions with timed undo capabilities is centralized. This change simplifies the ArchiveLocalAdsBloc, making it more focused on state management rather than orchestrating deletion timers, and provides a more robust and consistent user experience for undoing archived ad deletions.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
